### PR TITLE
fix(serialization): contain fastcdr/std exceptions in serialize() [P1]

### DIFF
--- a/rmw_unix_socket_cpp/src/serialization.cpp
+++ b/rmw_unix_socket_cpp/src/serialization.cpp
@@ -102,24 +102,33 @@ bool serialize(
   const message_type_support_callbacks_t * callbacks,
   std::vector<uint8_t> & buffer)
 {
-  // Get estimated serialized size (4 bytes encapsulation + message)
-  auto data_length = 4 + callbacks->get_serialized_size(ros_message);
-  buffer.resize(data_length);
+  try {
+    // Get estimated serialized size (4 bytes encapsulation + message)
+    auto data_length = 4 + callbacks->get_serialized_size(ros_message);
+    buffer.resize(data_length);
 
-  eprosima::fastcdr::FastBuffer fastbuffer(
-    reinterpret_cast<char *>(buffer.data()), data_length);
-  eprosima::fastcdr::Cdr ser(
-    fastbuffer,
-    eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
-    eprosima::fastcdr::CdrVersion::DDS_CDR);
+    eprosima::fastcdr::FastBuffer fastbuffer(
+      reinterpret_cast<char *>(buffer.data()), data_length);
+    eprosima::fastcdr::Cdr ser(
+      fastbuffer,
+      eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+      eprosima::fastcdr::CdrVersion::DDS_CDR);
 
-  ser.serialize_encapsulation();
-  if (!callbacks->cdr_serialize(ros_message, ser)) {
+    ser.serialize_encapsulation();
+    if (!callbacks->cdr_serialize(ros_message, ser)) {
+      return false;
+    }
+
+    // Trim buffer to actual serialized size
+    buffer.resize(ser.get_serialized_data_length());
+  } catch (const eprosima::fastcdr::exception::Exception &) {
+    return false;
+  } catch (const std::exception &) {
+    // get_serialized_size() can throw std::overflow_error (string/sequence
+    // overflow); buffer.resize() can throw std::bad_alloc. Callers are
+    // extern "C", so nothing may escape across the C ABI.
     return false;
   }
-
-  // Trim buffer to actual serialized size
-  buffer.resize(ser.get_serialized_data_length());
   return true;
 }
 


### PR DESCRIPTION
**Severity: P1** — found by a full multi-agent code audit of `rmw_unix_socket_cpp` (method + findings in `AUDIT_FINAL.md`).

## Problem
`serialize()` had **no** exception guard, while its sibling `deserialize()` wraps its fastcdr calls in `try/catch`. In `serialize()`:
- `callbacks->get_serialized_size()` can throw `std::overflow_error` (bounded sequence / string overflow);
- `ser.serialize_encapsulation()` / `callbacks->cdr_serialize()` can throw `eprosima::fastcdr::exception::Exception` (e.g. `BadParamException` on a `std::string` field carrying an embedded `\0`).

Every caller is `extern "C"` (`rmw_publish`, `rmw_serialize`, `rmw_send_request`, `rmw_send_response`), so a thrown exception unwinds across the C ABI into rcl → `std::terminate()` (process abort).

## Fix
Wrap the body of `serialize()` and return `false` on failure, mirroring `deserialize()`:
- `catch (const eprosima::fastcdr::exception::Exception &)` — fastcdr's `Exception` does **not** derive from `std::exception`, so it needs its own clause;
- `catch (const std::exception &)` — covers `get_serialized_size()`'s `std::overflow_error` and `buffer.resize()`'s `std::bad_alloc`.

All callers already do `if (!serialize(...)) return RMW_RET_ERROR;`.

**File:** `rmw_unix_socket_cpp/src/serialization.cpp`
**Build:** clean `colcon build` (library), 0 warnings.
