### PR TITLE
fix(init): deep-copy security_options in rmw_init_options_copy [P1]

### DIFF
--- a/rmw_unix_socket_cpp/src/rmw_init.cpp
+++ b/rmw_unix_socket_cpp/src/rmw_init.cpp
@@ -10,6 +10,7 @@
 #include "rmw/init.h"
 #include "rmw/init_options.h"
 #include "rmw/rmw.h"
+#include "rmw/security_options.h"
 
 extern "C"
 {
@@ -48,6 +49,14 @@ rmw_ret_t rmw_init_options_copy(
     return RMW_RET_INVALID_ARGUMENT;
   }
   *dst = *src;
+  // security_options.security_root_path is heap-owned; deep-copy it so src and
+  // dst don't alias the same pointer and double-free in rmw_init_options_fini.
+  dst->security_options = rmw_get_zero_initialized_security_options();
+  rmw_ret_t ret = rmw_security_options_copy(
+    &src->security_options, &src->allocator, &dst->security_options);
+  if (ret != RMW_RET_OK) {
+    return ret;
+  }
   if (src->enclave) {
     dst->enclave = rcutils_strdup(src->enclave, src->allocator);
   }


### PR DESCRIPTION
**Severity: P1** — found by a full multi-agent code audit (method + findings in `AUDIT_FINAL.md`).

## Problem
`rmw_init_options_copy()` did `*dst = *src` and only deep-copied `enclave`. `rmw_security_options_t::security_root_path` is a heap-owned `char *`, so after the shallow copy `src` and `dst` alias the same pointer. `rmw_init_options_fini()` calls `rmw_security_options_fini()`, so finalizing both copies (what rcl / init-options lifecycle code does) **frees `security_root_path` twice → heap corruption**. Latent until a security-enabled (sros2) deployment sets a non-null root.

## Fix
After `*dst = *src`, zero `dst->security_options` and deep-copy via `rmw_security_options_copy(...)`, returning the error on failure.

**File:** `rmw_unix_socket_cpp/src/rmw_init.cpp`
**Note:** the analogous `discovery_options` aliasing (P2-4) is addressed in the full-stack PR, not here.
**Build:** clean.
