### PR TITLE
fix(build): stop Rolling CMake configure aborting in the localhost_only probe

### DIFF
--- a/rmw_unix_socket_cpp/CMakeLists.txt
+++ b/rmw_unix_socket_cpp/CMakeLists.txt
@@ -22,8 +22,23 @@ find_package(rosidl_typesupport_fastrtps_cpp REQUIRED)
 # rmw_init_options_t::localhost_only was removed in Kilted (rmw >= 7.8).
 # Probe so we can keep setting it on older distros without breaking newer ones.
 include(CheckCXXSourceCompiles)
-set(_rmw_probe_saved_libs ${CMAKE_REQUIRED_LIBRARIES})
-set(CMAKE_REQUIRED_LIBRARIES rmw::rmw rcutils::rcutils)
+# The probe only needs the rmw headers, so feed it include dirs rather than
+# linking rmw::rmw / rcutils::rcutils. Linking the C rcutils target pulls its
+# INTERFACE_COMPILE_FEATURES (a C compile feature) into this CXX-only
+# try_compile; on toolchains where the scratch project doesn't enable C that
+# aborts configure with "No known features for C compiler" (seen on Rolling).
+set(_rmw_probe_saved_inc "${CMAKE_REQUIRED_INCLUDES}")
+# init_options.h pulls in rcutils/allocator.h, so the probe needs both the rmw
+# and rcutils include dirs (gathered without linking either target).
+set(CMAKE_REQUIRED_INCLUDES "")
+get_target_property(_rmw_probe_rmw_inc rmw::rmw INTERFACE_INCLUDE_DIRECTORIES)
+if(_rmw_probe_rmw_inc)
+  list(APPEND CMAKE_REQUIRED_INCLUDES ${_rmw_probe_rmw_inc})
+endif()
+get_target_property(_rmw_probe_rcutils_inc rcutils::rcutils INTERFACE_INCLUDE_DIRECTORIES)
+if(_rmw_probe_rcutils_inc)
+  list(APPEND CMAKE_REQUIRED_INCLUDES ${_rmw_probe_rcutils_inc})
+endif()
 check_cxx_source_compiles("
 #include <rmw/init_options.h>
 int main() {
@@ -32,7 +47,7 @@ int main() {
   return 0;
 }
 " RMW_HAS_LOCALHOST_ONLY)
-set(CMAKE_REQUIRED_LIBRARIES ${_rmw_probe_saved_libs})
+set(CMAKE_REQUIRED_INCLUDES "${_rmw_probe_saved_inc}")
 
 add_library(rmw_unix_socket_cpp SHARED
   src/registry.cpp


### PR DESCRIPTION
## Problem
On **Rolling**, `colcon build` aborts at CMake **configure** time, before any source compiles:

```
-- Performing Test RMW_HAS_LOCALHOST_ONLY
No known features for C compiler
  "" version .
Failed to generate test project build system.
```

The `RMW_HAS_LOCALHOST_ONLY` probe (commit `fb9ee3d`) runs `check_cxx_source_compiles(...)` with `CMAKE_REQUIRED_LIBRARIES = rmw::rmw rcutils::rcutils`, which links those imported targets into a **CXX-only** scratch project. `rcutils` is a **C** library whose exported target now carries a C `INTERFACE_COMPILE_FEATURES`; resolving a C compile feature in a project where the C language was never enabled makes the inner `try_compile` fail to *generate*. This is upstream drift — the same `CMakeLists.txt` passed Rolling on 2026-06-01, and `jazzy`/`kilted` are unaffected.

## Fix
The probe only needs the rmw **headers** (it references the type + a macro and links nothing). Feed it the `rmw` and `rcutils` include dirs via `CMAKE_REQUIRED_INCLUDES` instead of linking the targets — no imported target is linked, so no C compile-feature is pulled into the CXX scratch project. (`rmw/init_options.h` transitively includes `rcutils/allocator.h`, hence both include dirs.)

## Verified
- Local clean build on **jazzy** (rmw 7.3.3, field present): probe correctly detects it → `-DRMW_HAS_LOCALHOST_ONLY=1`, builds clean with 0 warnings.
- Field presence by distro: jazzy 7.3.3 **has** `localhost_only`; kilted 7.8.2 and rolling 7.10.1 do **not** (removed at rmw 7.8) — the probe resolves correctly on each.

Independent of the audit-fix PRs (#4–#9); fixes Rolling CI for all of them once merged.
