### PR TITLE
perf(registry): filter by type before the per-slot snapshot copy

### DIFF
--- a/rmw_unix_socket_cpp/src/registry.cpp
+++ b/rmw_unix_socket_cpp/src/registry.cpp
@@ -355,6 +355,13 @@ void registry_cleanup_stale(RegistryHeader * header)
   uint32_t max = header->max_entries;
 
   for (uint32_t i = 0; i < max; ++i) {
+    // Fast-skip empty slots without snapshotting, mirroring registry_query.
+    // snapshot_slot would also bail on EMPTY, but only after loading seq; this
+    // drops that load for the empty slots in the 32768-slot scan. A slot that
+    // turns non-empty just after the skip is reclaimed on the next sweep.
+    if (slots[i].state.load(std::memory_order_acquire) == ENTRY_EMPTY) {
+      continue;
+    }
     RegistryEntrySlot snap;
     uint32_t snap_seq;
     if (!snapshot_slot(&slots[i], &snap, &snap_seq)) {
@@ -432,6 +439,14 @@ std::vector<RegistryQueryResult> registry_query(
     // Fast pre-check: skip clearly-empty slots without snapshotting.
     uint8_t pre_state = slots[i].state.load(std::memory_order_acquire);
     if (pre_state == ENTRY_EMPTY) {
+      continue;
+    }
+    // Type pre-filter: skip the full snapshot for slots whose current type
+    // can't match. pre_state is only an early-out — a slot rewritten to a
+    // different type between this load and the snapshot is still rejected by
+    // the authoritative post-snapshot type re-check below, so results stay
+    // seqlock-consistent. (RESERVED/EMPTY never equal a real type_filter.)
+    if (type_filter != ENTRY_EMPTY && pre_state != static_cast<uint8_t>(type_filter)) {
       continue;
     }
 

--- a/rmw_unix_socket_cpp/test/test_registry.cpp
+++ b/rmw_unix_socket_cpp/test/test_registry.cpp
@@ -129,6 +129,54 @@ TEST_F(RegistryTest, QueryFiltersByType)
   EXPECT_EQ(2u, all.size());
 }
 
+// Pins the invariant that the type pre-filter (which short-circuits on the
+// pre-snapshot state) must still return exactly the entry whose validated
+// type matches — with same-topic decoys of other types present. Guards
+// against a future edit dropping the authoritative post-snapshot re-check.
+TEST_F(RegistryTest, QueryTypeFilterExcludesOtherTypesSameTopic)
+{
+  auto * header = rmw_uds::registry_header(registry_ptr);
+
+  rmw_uds::RegistryEntry pub_entry;
+  std::memset(&pub_entry, 0, sizeof(pub_entry));
+  pub_entry.type = rmw_uds::ENTRY_PUBLISHER;
+  pub_entry.pid = getpid();
+  std::strncpy(pub_entry.topic_name, "/shared", sizeof(pub_entry.topic_name) - 1);
+
+  rmw_uds::RegistryEntry sub_entry;
+  std::memset(&sub_entry, 0, sizeof(sub_entry));
+  sub_entry.type = rmw_uds::ENTRY_SUBSCRIPTION;
+  sub_entry.pid = getpid();
+  std::strncpy(sub_entry.topic_name, "/shared", sizeof(sub_entry.topic_name) - 1);
+
+  rmw_uds::RegistryEntry srv_entry;
+  std::memset(&srv_entry, 0, sizeof(srv_entry));
+  srv_entry.type = rmw_uds::ENTRY_SERVICE;
+  srv_entry.pid = getpid();
+  std::strncpy(srv_entry.topic_name, "/shared", sizeof(srv_entry.topic_name) - 1);
+
+  int32_t pub_idx = rmw_uds::registry_add(header, pub_entry);
+  int32_t sub_idx = rmw_uds::registry_add(header, sub_entry);
+  int32_t srv_idx = rmw_uds::registry_add(header, srv_entry);
+  ASSERT_GE(pub_idx, 0);
+  ASSERT_GE(sub_idx, 0);
+  ASSERT_GE(srv_idx, 0);
+
+  auto pubs = rmw_uds::registry_query(
+    header, rmw_uds::ENTRY_PUBLISHER, "/shared", nullptr, nullptr);
+  auto subs = rmw_uds::registry_query(
+    header, rmw_uds::ENTRY_SUBSCRIPTION, "/shared", nullptr, nullptr);
+
+  rmw_uds::registry_remove(header, pub_idx);
+  rmw_uds::registry_remove(header, sub_idx);
+  rmw_uds::registry_remove(header, srv_idx);
+
+  ASSERT_EQ(1u, pubs.size());
+  EXPECT_EQ(rmw_uds::ENTRY_PUBLISHER, pubs[0].type);
+  ASSERT_EQ(1u, subs.size());
+  EXPECT_EQ(rmw_uds::ENTRY_SUBSCRIPTION, subs[0].type);
+}
+
 TEST_F(RegistryTest, MultipleEntriesSameType)
 {
   auto * header = rmw_uds::registry_header(registry_ptr);


### PR DESCRIPTION
## What

Two pure cost reductions on the registry read path, in `registry.cpp`:

- **`registry_query`**: apply the type filter using the already-loaded `pre_state` *before* calling `snapshot_slot`. Slots whose current type does not match a typed query are skipped without the ~1.1 KB, six-`memcpy` snapshot copy. The authoritative post-snapshot type re-check (derived from the seqlock-validated snapshot) is kept, so results stay seqlock-consistent.
- **`registry_cleanup_stale`**: add a `state.load(acquire) == ENTRY_EMPTY` fast-skip before `snapshot_slot`, mirroring the pre-check already used by `registry_query`. This drops the `seq` load for the tens of thousands of empty slots in a 32768-slot scan and makes the two scan loops symmetric.

## Why

A perftest (200 TRANSIENT_LOCAL publishers, one node restarted every 5 s) showed the registry scan dominated by `registry_query`'s per-slot snapshot `memcpy` and by per-slot atomic loads across the full slot array. Every hot-path caller passes a concrete type filter, so a typed query currently snapshots ~99% of slots only to reject them on type. Filtering on the cheap `pre_state` first skips that copy for non-matching slots.

## Impact

Behavior-preserving — query results and cleanup outcomes are byte-for-byte identical; this only removes work. The type pre-filter is an early-out; correctness still rests on the post-snapshot type re-check, which is retained and now pinned by a dedicated test. No new visibility guarantee is added or removed: a concurrent add racing the scan may or may not be observed, exactly as before.

## Test

- Existing `QueryFiltersByType`, `CleanupStaleRemovesDeadPidEntries`, `AddReclaimsStaleSlotsOnOverflow`, `AddOverflowKeepsLivePidEntries`, and the concurrent torn-read tests guard the change.
- Added `QueryTypeFilterExcludesOtherTypesSameTopic`: a publisher, a subscription, and a service all on `/shared`; typed queries must return exactly the matching entry. This locks the invariant that the type pre-filter must not silently drop the authoritative post-snapshot re-check.

## Version

No `REGISTRY_VERSION` bump — no shared-memory struct/layout changes.