### PR TITLE
perf: copy-on-write subscriber-path cache and prune stale known-subscriber set on graph change

### DIFF
--- a/rmw_unix_socket_cpp/src/rmw_publisher.cpp
+++ b/rmw_unix_socket_cpp/src/rmw_publisher.cpp
@@ -213,23 +213,26 @@ rmw_ret_t rmw_publish(
   auto * header = rmw_uds::registry_header(pub_data->context->registry_ptr);
   uint64_t current_gen = rmw_uds::registry_generation(header);
 
-  std::vector<std::string> sub_paths;
+  std::shared_ptr<const std::vector<std::string>> sub_paths;
+  bool refreshed = false;
   {
     std::lock_guard<std::mutex> lock(pub_data->sub_cache_mutex);
     if (current_gen != pub_data->cached_generation) {
       auto subs = rmw_uds::registry_query(
         header, rmw_uds::ENTRY_SUBSCRIPTION, pub_data->topic_name.c_str(),
         nullptr, nullptr);
-      pub_data->cached_generation = current_gen;
-      pub_data->cached_subscriber_paths.clear();
-      pub_data->cached_subscriber_paths.reserve(subs.size());
+      auto fresh = std::make_shared<std::vector<std::string>>();
+      fresh->reserve(subs.size());
       for (const auto & s : subs) {
         if (!s.socket_path.empty()) {
-          pub_data->cached_subscriber_paths.push_back(s.socket_path);
+          fresh->push_back(s.socket_path);
         }
       }
+      pub_data->cached_generation = current_gen;
+      pub_data->cached_subscriber_paths = std::move(fresh);
+      refreshed = true;
     }
-    sub_paths = pub_data->cached_subscriber_paths;  // copy under lock
+    sub_paths = pub_data->cached_subscriber_paths;  // refcount copy under lock
   }
 
   // TRANSIENT_LOCAL: cache message and replay to late-joining subscribers
@@ -244,14 +247,28 @@ rmw_ret_t rmw_publish(
       pub_data->message_cache.pop_front();
     }
 
-    for (const auto & path : sub_paths) {
-      if (pub_data->known_subscriber_paths.count(path) == 0) {
-        pub_data->known_subscriber_paths.insert(path);
-        for (size_t i = 0; i + 1 < pub_data->message_cache.size(); ++i) {
-          const auto & cm = pub_data->message_cache[i];
-          rmw_uds::send_to(
-            pub_data->context->send_socket_fd,
-            path, cm.header, cm.payload.data(), cm.payload.size());
+    // On a graph change, drop known subscribers that are no longer present so
+    // the set tracks only live subs (a reappearing sub gets a fresh path).
+    if (refreshed) {
+      std::set<std::string> current(sub_paths->begin(), sub_paths->end());
+      for (auto it = pub_data->known_subscriber_paths.begin();
+        it != pub_data->known_subscriber_paths.end(); )
+      {
+        it = (current.count(*it) == 0) ?
+          pub_data->known_subscriber_paths.erase(it) : std::next(it);
+      }
+    }
+
+    if (sub_paths) {
+      for (const auto & path : *sub_paths) {
+        if (pub_data->known_subscriber_paths.count(path) == 0) {
+          pub_data->known_subscriber_paths.insert(path);
+          for (size_t i = 0; i + 1 < pub_data->message_cache.size(); ++i) {
+            const auto & cm = pub_data->message_cache[i];
+            rmw_uds::send_to(
+              pub_data->context->send_socket_fd,
+              path, cm.header, cm.payload.data(), cm.payload.size());
+          }
         }
       }
     }
@@ -259,22 +276,26 @@ rmw_ret_t rmw_publish(
     // Send the current message, read from the cached copy since payload was
     // moved. Trimming never disturbs back(), so it is the message just pushed.
     const auto & current = pub_data->message_cache.back();
-    for (const auto & path : sub_paths) {
-      rmw_uds::send_to(
-        pub_data->context->send_socket_fd,
-        path, current.header, current.payload.data(), current.payload.size());
+    if (sub_paths) {
+      for (const auto & path : *sub_paths) {
+        rmw_uds::send_to(
+          pub_data->context->send_socket_fd,
+          path, current.header, current.payload.data(), current.payload.size());
+      }
     }
     return RMW_RET_OK;
   }
 
   // Surface EMSGSIZE; soft drops (EAGAIN/ENOENT) are logged in send_to.
   bool config_error = false;
-  for (const auto & path : sub_paths) {
-    if (rmw_uds::send_to(
-        pub_data->context->send_socket_fd,
-        path, hdr, payload.data(), payload.size()) == rmw_uds::SendResult::ConfigError)
-    {
-      config_error = true;
+  if (sub_paths) {
+    for (const auto & path : *sub_paths) {
+      if (rmw_uds::send_to(
+          pub_data->context->send_socket_fd,
+          path, hdr, payload.data(), payload.size()) == rmw_uds::SendResult::ConfigError)
+      {
+        config_error = true;
+      }
     }
   }
   if (config_error) {
@@ -312,33 +333,36 @@ rmw_ret_t rmw_publish_serialized_message(
   // Reuse the cached subscriber list (refresh only on graph change)
   auto * header = rmw_uds::registry_header(pub_data->context->registry_ptr);
   uint64_t current_gen = rmw_uds::registry_generation(header);
-  std::vector<std::string> sub_paths;
+  std::shared_ptr<const std::vector<std::string>> sub_paths;
   {
     std::lock_guard<std::mutex> lock(pub_data->sub_cache_mutex);
     if (current_gen != pub_data->cached_generation) {
       auto subs = rmw_uds::registry_query(
         header, rmw_uds::ENTRY_SUBSCRIPTION, pub_data->topic_name.c_str(),
         nullptr, nullptr);
-      pub_data->cached_generation = current_gen;
-      pub_data->cached_subscriber_paths.clear();
-      pub_data->cached_subscriber_paths.reserve(subs.size());
+      auto fresh = std::make_shared<std::vector<std::string>>();
+      fresh->reserve(subs.size());
       for (const auto & s : subs) {
         if (!s.socket_path.empty()) {
-          pub_data->cached_subscriber_paths.push_back(s.socket_path);
+          fresh->push_back(s.socket_path);
         }
       }
+      pub_data->cached_generation = current_gen;
+      pub_data->cached_subscriber_paths = std::move(fresh);
     }
     sub_paths = pub_data->cached_subscriber_paths;
   }
 
   bool config_error = false;
-  for (const auto & path : sub_paths) {
-    if (rmw_uds::send_to(
-        pub_data->context->send_socket_fd,
-        path, hdr, serialized_message->buffer,
-        serialized_message->buffer_length) == rmw_uds::SendResult::ConfigError)
-    {
-      config_error = true;
+  if (sub_paths) {
+    for (const auto & path : *sub_paths) {
+      if (rmw_uds::send_to(
+          pub_data->context->send_socket_fd,
+          path, hdr, serialized_message->buffer,
+          serialized_message->buffer_length) == rmw_uds::SendResult::ConfigError)
+      {
+        config_error = true;
+      }
     }
   }
   if (config_error) {

--- a/rmw_unix_socket_cpp/src/rmw_publisher.cpp
+++ b/rmw_unix_socket_cpp/src/rmw_publisher.cpp
@@ -214,7 +214,6 @@ rmw_ret_t rmw_publish(
   uint64_t current_gen = rmw_uds::registry_generation(header);
 
   std::shared_ptr<const std::vector<std::string>> sub_paths;
-  bool refreshed = false;
   {
     std::lock_guard<std::mutex> lock(pub_data->sub_cache_mutex);
     if (current_gen != pub_data->cached_generation) {
@@ -230,7 +229,24 @@ rmw_ret_t rmw_publish(
       }
       pub_data->cached_generation = current_gen;
       pub_data->cached_subscriber_paths = std::move(fresh);
-      refreshed = true;
+
+      // Prune known subscribers no longer present, against the freshly-built
+      // canonical list while STILL holding sub_cache_mutex (nested lock order
+      // sub_cache_mutex -> cache_mutex), so a concurrent refresh on another
+      // thread (e.g. the rmw_wait replay path) cannot make the pruning set
+      // stale and erase a still-live late-joiner.
+      if (pub_data->qos.durability == RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL) {
+        std::lock_guard<std::mutex> prune_lock(pub_data->cache_mutex);
+        std::set<std::string> current(
+          pub_data->cached_subscriber_paths->begin(),
+          pub_data->cached_subscriber_paths->end());
+        for (auto it = pub_data->known_subscriber_paths.begin();
+          it != pub_data->known_subscriber_paths.end(); )
+        {
+          it = (current.count(*it) == 0) ?
+            pub_data->known_subscriber_paths.erase(it) : std::next(it);
+        }
+      }
     }
     sub_paths = pub_data->cached_subscriber_paths;  // refcount copy under lock
   }
@@ -245,18 +261,6 @@ rmw_ret_t rmw_publish(
     pub_data->message_cache.push_back(std::move(cached));
     while (pub_data->message_cache.size() > pub_data->qos.depth) {
       pub_data->message_cache.pop_front();
-    }
-
-    // On a graph change, drop known subscribers that are no longer present so
-    // the set tracks only live subs (a reappearing sub gets a fresh path).
-    if (refreshed) {
-      std::set<std::string> current(sub_paths->begin(), sub_paths->end());
-      for (auto it = pub_data->known_subscriber_paths.begin();
-        it != pub_data->known_subscriber_paths.end(); )
-      {
-        it = (current.count(*it) == 0) ?
-          pub_data->known_subscriber_paths.erase(it) : std::next(it);
-      }
     }
 
     if (sub_paths) {

--- a/rmw_unix_socket_cpp/src/rmw_wait.cpp
+++ b/rmw_unix_socket_cpp/src/rmw_wait.cpp
@@ -6,7 +6,10 @@
 #include <cerrno>
 #include <chrono>
 #include <cstring>
+#include <iterator>
 #include <limits>
+#include <memory>
+#include <set>
 
 #include <sys/epoll.h>
 #include <sys/eventfd.h>
@@ -176,26 +179,42 @@ rmw_ret_t rmw_wait(
       // is what keeps each pub pointer alive while we dereference it.
       std::lock_guard<std::mutex> tl_lock(ctx->transient_local_pubs_mutex);
       for (auto * pub : ctx->transient_local_pubs) {
-        std::vector<std::string> sub_paths;
+        std::shared_ptr<const std::vector<std::string>> sub_paths;
+        bool refreshed = false;
         {
           std::lock_guard<std::mutex> sc_lock(pub->sub_cache_mutex);
           if (rmw_uds::registry_generation(header) != pub->cached_generation) {
             auto subs = rmw_uds::registry_query(
               header, rmw_uds::ENTRY_SUBSCRIPTION,
               pub->topic_name.c_str(), nullptr, nullptr);
-            pub->cached_generation = rmw_uds::registry_generation(header);
-            pub->cached_subscriber_paths.clear();
-            pub->cached_subscriber_paths.reserve(subs.size());
+            auto fresh = std::make_shared<std::vector<std::string>>();
+            fresh->reserve(subs.size());
             for (const auto & s : subs) {
               if (!s.socket_path.empty()) {
-                pub->cached_subscriber_paths.push_back(s.socket_path);
+                fresh->push_back(s.socket_path);
               }
             }
+            pub->cached_generation = rmw_uds::registry_generation(header);
+            pub->cached_subscriber_paths = std::move(fresh);
+            refreshed = true;
           }
           sub_paths = pub->cached_subscriber_paths;
         }
         std::lock_guard<std::mutex> c_lock(pub->cache_mutex);
-        for (const auto & path : sub_paths) {
+        // On a graph change, drop known subscribers that are no longer present.
+        if (refreshed && sub_paths) {
+          std::set<std::string> current(sub_paths->begin(), sub_paths->end());
+          for (auto it = pub->known_subscriber_paths.begin();
+            it != pub->known_subscriber_paths.end(); )
+          {
+            it = (current.count(*it) == 0) ?
+              pub->known_subscriber_paths.erase(it) : std::next(it);
+          }
+        }
+        if (!sub_paths) {
+          continue;
+        }
+        for (const auto & path : *sub_paths) {
           if (pub->known_subscriber_paths.count(path) != 0) {
             continue;
           }

--- a/rmw_unix_socket_cpp/src/rmw_wait.cpp
+++ b/rmw_unix_socket_cpp/src/rmw_wait.cpp
@@ -180,7 +180,6 @@ rmw_ret_t rmw_wait(
       std::lock_guard<std::mutex> tl_lock(ctx->transient_local_pubs_mutex);
       for (auto * pub : ctx->transient_local_pubs) {
         std::shared_ptr<const std::vector<std::string>> sub_paths;
-        bool refreshed = false;
         {
           std::lock_guard<std::mutex> sc_lock(pub->sub_cache_mutex);
           if (rmw_uds::registry_generation(header) != pub->cached_generation) {
@@ -196,21 +195,26 @@ rmw_ret_t rmw_wait(
             }
             pub->cached_generation = rmw_uds::registry_generation(header);
             pub->cached_subscriber_paths = std::move(fresh);
-            refreshed = true;
+
+            // Prune known subscribers no longer present, against the freshly-
+            // built canonical list while STILL holding sub_cache_mutex (nested
+            // lock order sub_cache_mutex -> cache_mutex), so a concurrent
+            // refresh (e.g. from rmw_publish) cannot make the pruning set stale
+            // and erase a still-live late-joiner.
+            std::lock_guard<std::mutex> prune_lock(pub->cache_mutex);
+            std::set<std::string> current(
+              pub->cached_subscriber_paths->begin(),
+              pub->cached_subscriber_paths->end());
+            for (auto it = pub->known_subscriber_paths.begin();
+              it != pub->known_subscriber_paths.end(); )
+            {
+              it = (current.count(*it) == 0) ?
+                pub->known_subscriber_paths.erase(it) : std::next(it);
+            }
           }
           sub_paths = pub->cached_subscriber_paths;
         }
         std::lock_guard<std::mutex> c_lock(pub->cache_mutex);
-        // On a graph change, drop known subscribers that are no longer present.
-        if (refreshed && sub_paths) {
-          std::set<std::string> current(sub_paths->begin(), sub_paths->end());
-          for (auto it = pub->known_subscriber_paths.begin();
-            it != pub->known_subscriber_paths.end(); )
-          {
-            it = (current.count(*it) == 0) ?
-              pub->known_subscriber_paths.erase(it) : std::next(it);
-          }
-        }
         if (!sub_paths) {
           continue;
         }

--- a/rmw_unix_socket_cpp/src/types.hpp
+++ b/rmw_unix_socket_cpp/src/types.hpp
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <cstring>
 #include <deque>
+#include <memory>
 #include <mutex>
 #include <set>
 #include <string>
@@ -143,7 +144,9 @@ struct UdsPublisher
   // generation counter changes (graph topology actually changed).
   std::mutex sub_cache_mutex;
   uint64_t cached_generation = 0;
-  std::vector<std::string> cached_subscriber_paths;
+  // Copy-on-write: swapped wholesale on graph-generation change so the publish/
+  // wait hot path copies one refcount instead of N strings. Null until first refresh.
+  std::shared_ptr<const std::vector<std::string>> cached_subscriber_paths;
 
   // TRANSIENT_LOCAL: cache of last N messages for late-joining subscribers
   std::mutex cache_mutex;

--- a/rmw_unix_socket_cpp/test/test_rmw_qos.cpp
+++ b/rmw_unix_socket_cpp/test/test_rmw_qos.cpp
@@ -93,6 +93,53 @@ TEST_F(QosTest, TransientLocalLateJoiner)
   auto _r2 [[maybe_unused]] = rmw_destroy_publisher(node, pub);
 }
 
+TEST_F(QosTest, KnownSubscriberPathsPrunedOnChurn)
+{
+  // The publisher's known_subscriber_paths must not accumulate dead entries as
+  // subscribers churn: each create/destroy bumps the registry generation, and a
+  // restarted subscriber gets a brand-new unique socket path. Without pruning on
+  // refresh the set is insert-only and grows by one per churned subscriber.
+  auto qos = make_qos(
+    RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+    RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL, 5);
+
+  auto pub_opts = rmw_get_default_publisher_options();
+  auto * pub = rmw_create_publisher(node, ts, "/churn", &qos, &pub_opts);
+  ASSERT_NE(nullptr, pub);
+
+  // Seed the cache so there is something to replay.
+  test_msgs::msg::BasicTypes seed;
+  seed.int32_value = 1;
+  EXPECT_EQ(RMW_RET_OK, rmw_publish(pub, &seed, nullptr));
+
+  auto sub_opts = rmw_get_default_subscription_options();
+  constexpr int kChurn = 8;
+  for (int i = 0; i < kChurn; ++i) {
+    // New sub bumps generation -> next publish refreshes + records this sub.
+    auto * sub = rmw_create_subscription(node, ts, "/churn", &qos, &sub_opts);
+    ASSERT_NE(nullptr, sub);
+    test_msgs::msg::BasicTypes m;
+    m.int32_value = i + 2;
+    EXPECT_EQ(RMW_RET_OK, rmw_publish(pub, &m, nullptr));
+    // Destroy bumps generation again; next publish refreshes + prunes the gone sub.
+    auto _r [[maybe_unused]] = rmw_destroy_subscription(node, sub);
+    EXPECT_EQ(RMW_RET_OK, rmw_publish(pub, &m, nullptr));
+  }
+
+  // After the loop every churned sub is destroyed, so known should be empty.
+  auto * pub_data = static_cast<rmw_uds::UdsPublisher *>(pub->data);
+  size_t known_size = 0;
+  {
+    std::lock_guard<std::mutex> lock(pub_data->cache_mutex);
+    known_size = pub_data->known_subscriber_paths.size();
+  }
+  // With the prune: tracks only live subs (0 here). Without it: grows to kChurn.
+  EXPECT_LE(known_size, 1u)
+    << "known_subscriber_paths leaked dead entries: size=" << known_size;
+
+  auto _r2 [[maybe_unused]] = rmw_destroy_publisher(node, pub);
+}
+
 TEST_F(QosTest, TransientLocalCacheDepthEnforced)
 {
   auto qos = make_qos(


### PR DESCRIPTION
## What

Two paired changes in the TRANSIENT_LOCAL / fanout publish-and-wait refresh blocks of `UdsPublisher`:

1. **Copy-on-write subscriber-path cache.** `UdsPublisher::cached_subscriber_paths` changes from `std::vector<std::string>` to `std::shared_ptr<const std::vector<std::string>>`. On a graph-generation change the path list is rebuilt into a fresh vector and swapped in as a new shared_ptr. The per-publish / per-wait hot path now copies a single refcount instead of deep-copying N `std::string`s, then iterates `*sub_paths` behind a null guard.

2. **Prune `known_subscriber_paths` on refresh.** The replay bookkeeping set was insert-only and grew without bound under node churn: each restarted node's subscriber mints a brand-new unique socket path (PID + counter + time) that was never removed. On the refresh branch (generation change only) the set is now intersected with the freshly-rebuilt path list, dropping paths whose subscriber is gone.

## Why

Re-audit against a 200-publisher all-TRANSIENT_LOCAL workload with a node restarting every 5s showed (a) N string allocations per publish for the fanout path copy, and (b) unbounded growth of `known_subscriber_paths` under churn, which also slows the per-publish set lookups over time.

## Impact

- Publish/wait hot path: one atomic refcount bump instead of N heap string copies per call.
- `known_subscriber_paths` now tracks only currently-live subscribers, so memory and per-publish lookup cost stay bounded under churn.
- TRANSIENT_LOCAL late-joiner replay semantics are unchanged: a still-present subscriber is never replayed twice; a subscriber that vanishes and reappears gets a fresh unique path and is correctly replayed as a new late-joiner.

## Test

New `QosTest.KnownSubscriberPathsPrunedOnChurn`: churns TRANSIENT_LOCAL subscribers on one publisher and asserts `known_subscriber_paths` does not accumulate dead entries (fails without the prune, where the set grows by one per churned subscriber). Existing TRANSIENT_LOCAL replay, depth-eviction, wait-side replay, and multi-subscriber fanout tests guard the behavior-preserving shared_ptr swap.

## Version bump

None. Both fields are process-local heap members of `UdsPublisher` and are never mapped into the cross-process shared-memory registry, so the registry layout and `REGISTRY_VERSION` are untouched.