### PR TITLE
perf: cache rmw_service_server_is_available on registry generation

### DIFF
--- a/rmw_unix_socket_cpp/src/rmw_client.cpp
+++ b/rmw_unix_socket_cpp/src/rmw_client.cpp
@@ -206,6 +206,7 @@ rmw_ret_t rmw_send_request(
           break;
         }
       }
+      cli_data->cached_is_available = !services.empty();
     }
     service_path = cli_data->cached_service_path;
   }
@@ -338,10 +339,24 @@ rmw_ret_t rmw_service_server_is_available(
   auto * cli_data = static_cast<rmw_uds::UdsClient *>(client->data);
   auto * header = rmw_uds::registry_header(cli_data->context->registry_ptr);
 
-  auto services = rmw_uds::registry_query(
-    header, rmw_uds::ENTRY_SERVICE, cli_data->service_name.c_str(), nullptr, nullptr);
-
-  *is_available = !services.empty();
+  // PERFORMANCE: only re-query the registry on graph generation change;
+  // shares the generation/cache with rmw_send_request (one scan per change).
+  uint64_t current_gen = rmw_uds::registry_generation(header);
+  std::lock_guard<std::mutex> lock(cli_data->svc_cache_mutex);
+  if (current_gen != cli_data->cached_generation) {
+    auto services = rmw_uds::registry_query(
+      header, rmw_uds::ENTRY_SERVICE, cli_data->service_name.c_str(), nullptr, nullptr);
+    cli_data->cached_generation = current_gen;
+    cli_data->cached_service_path.clear();
+    for (const auto & srv : services) {
+      if (!srv.socket_path.empty()) {
+        cli_data->cached_service_path = srv.socket_path;
+        break;
+      }
+    }
+    cli_data->cached_is_available = !services.empty();
+  }
+  *is_available = cli_data->cached_is_available;
   return RMW_RET_OK;
 }
 

--- a/rmw_unix_socket_cpp/src/types.hpp
+++ b/rmw_unix_socket_cpp/src/types.hpp
@@ -234,6 +234,7 @@ struct UdsClient
   std::mutex svc_cache_mutex;
   uint64_t cached_generation = 0;
   std::string cached_service_path;
+  bool cached_is_available = false;
 
   // Callback support
   std::mutex callback_mutex;

--- a/rmw_unix_socket_cpp/test/test_rmw_service_client.cpp
+++ b/rmw_unix_socket_cpp/test/test_rmw_service_client.cpp
@@ -65,6 +65,12 @@ TEST_F(ServiceClientTest, ServiceServerIsAvailable)
 
   EXPECT_EQ(RMW_RET_OK, rmw_service_server_is_available(node, cli, &available));
   EXPECT_TRUE(available);
+
+  // Same generation (no graph change): the cached short-circuit must return
+  // the cached value, not a stale default.
+  available = false;
+  EXPECT_EQ(RMW_RET_OK, rmw_service_server_is_available(node, cli, &available));
+  EXPECT_TRUE(available);
 }
 
 TEST_F(ServiceClientTest, RequestResponseRoundTrip)


### PR DESCRIPTION
## What

`rmw_service_server_is_available` ran a full `registry_query` on every call, allocating a `std::vector<RegistryQueryResult>` and scanning all 32768 registry slots (per-slot `std::atomic::load` + snapshot). rclcpp tight-polls this function from `wait_for_service`, so on a 150-node system this scan dominates the availability path.

This change gives the function the same generation-keyed short-circuit that `rmw_send_request` already uses: it skips the query when the registry generation counter is unchanged and returns the cached result instead.

## Why

A re-audit under a 200-publisher / TRANSIENT_LOCAL load (one node restarted every 5s) flagged the per-slot atomic scan in `registry_query` as ~20% of CPU. `rmw_send_request` already avoids re-scanning on each call by caching the last registry generation; `rmw_service_server_is_available` was the remaining hot consumer that scanned unconditionally.

The two functions now share `svc_cache_mutex` and `cached_generation`, so whichever runs first after a graph change does a single re-query that refreshes both the cached service path (for send) and the cached availability bool (for is_available). On the common unchanged-generation tick, neither function scans.

## Impact

- Eliminates the per-call vector allocation and 32768-slot atomic scan from `rmw_service_server_is_available` whenever the graph generation is unchanged (the steady-state polling case).
- Behavior-preserving: `is_available` still resolves to `!services.empty()`, and the cache is invalidated on every `registry_add`/`registry_remove` (each bumps the generation), so availability still flips correctly across a graph change.

## Test

Extended `ServiceClientTest.ServiceServerIsAvailable` to:
- cross the false->true cache-invalidation boundary (client created, then service created, generation bumps) — already covered, now also guards the new cache; and
- call `rmw_service_server_is_available` a second time at the same generation and assert it still returns true — exercises the cached (no-rescan) branch.

All `test_rmw_service_client` cases pass before and after.

## Version bump

None required. `cached_is_available` is a process-local field on the heap-allocated `UdsClient`; no shared-memory struct (`RegistryHeader` / `RegistryEntrySlot`) layout changed, so `REGISTRY_VERSION` is unchanged.