### PR TITLE
perf(registry): bound query/cleanup scans with a shared high-water mark

### DIFF
--- a/rmw_unix_socket_cpp/src/registry.cpp
+++ b/rmw_unix_socket_cpp/src/registry.cpp
@@ -249,15 +249,19 @@ static int32_t try_add_once(RegistryHeader * header, const RegistryEntry & entry
       // Payload is committed (seq even). Publish the real type with release
       // ordering so any reader that now sees it also sees the payload.
       slots[i].state.store(static_cast<uint8_t>(entry.type), std::memory_order_release);
-      header->generation.fetch_add(1, std::memory_order_acq_rel);
-      // Bump the high-water bound to max(current, i+1). Relaxed is sound: the
-      // per-slot state release/acquire already orders payload visibility; this
-      // only widens which slots query/cleanup bother to scan.
+      // Widen the high-water bound to max(current, i+1) BEFORE bumping the
+      // generation. Readers gate their re-query on a generation acquire-load and
+      // then read high_water; if this store were sequenced AFTER the release
+      // generation bump, a reader could observe the new generation but a stale
+      // high_water, scan [0, stale) and miss this just-added slot. Done first,
+      // the relaxed store is sequenced-before the release fetch_add, so any
+      // reader that synchronizes on the generation also observes high_water.
       uint32_t want = i + 1;
       uint32_t cur = header->high_water_slot.load(std::memory_order_relaxed);
       while (cur < want &&
              !header->high_water_slot.compare_exchange_weak(
                cur, want, std::memory_order_relaxed, std::memory_order_relaxed)) {}
+      header->generation.fetch_add(1, std::memory_order_acq_rel);
       return static_cast<int32_t>(i);
     }
   }

--- a/rmw_unix_socket_cpp/src/registry.cpp
+++ b/rmw_unix_socket_cpp/src/registry.cpp
@@ -48,6 +48,7 @@ static void initialize_header(RegistryHeader * header, size_t total_size)
   std::memset(static_cast<void *>(header), 0, total_size);
   header->max_entries = REGISTRY_MAX_ENTRIES;
   header->generation.store(0, std::memory_order_relaxed);
+  header->high_water_slot.store(0, std::memory_order_relaxed);
 
   pthread_mutexattr_t attr;
   pthread_mutexattr_init(&attr);
@@ -249,6 +250,14 @@ static int32_t try_add_once(RegistryHeader * header, const RegistryEntry & entry
       // ordering so any reader that now sees it also sees the payload.
       slots[i].state.store(static_cast<uint8_t>(entry.type), std::memory_order_release);
       header->generation.fetch_add(1, std::memory_order_acq_rel);
+      // Bump the high-water bound to max(current, i+1). Relaxed is sound: the
+      // per-slot state release/acquire already orders payload visibility; this
+      // only widens which slots query/cleanup bother to scan.
+      uint32_t want = i + 1;
+      uint32_t cur = header->high_water_slot.load(std::memory_order_relaxed);
+      while (cur < want &&
+             !header->high_water_slot.compare_exchange_weak(
+               cur, want, std::memory_order_relaxed, std::memory_order_relaxed)) {}
       return static_cast<int32_t>(i);
     }
   }
@@ -352,7 +361,10 @@ static const char * entry_type_name(uint8_t t)
 void registry_cleanup_stale(RegistryHeader * header)
 {
   auto * slots = registry_slots(header);
+  // Scan only [0, high_water): over-scan is safe, under-scan is impossible.
+  uint32_t hw = header->high_water_slot.load(std::memory_order_acquire);
   uint32_t max = header->max_entries;
+  if (hw < max) { max = hw; }
 
   for (uint32_t i = 0; i < max; ++i) {
     // Fast-skip empty slots without snapshotting, mirroring registry_query.
@@ -433,7 +445,10 @@ std::vector<RegistryQueryResult> registry_query(
 {
   std::vector<RegistryQueryResult> results;
   auto * slots = registry_slots(header);
+  // Scan only [0, high_water): over-scan is safe, under-scan is impossible.
+  uint32_t hw = header->high_water_slot.load(std::memory_order_acquire);
   uint32_t max = header->max_entries;
+  if (hw < max) { max = hw; }
 
   for (uint32_t i = 0; i < max; ++i) {
     // Fast pre-check: skip clearly-empty slots without snapshotting.

--- a/rmw_unix_socket_cpp/src/registry.hpp
+++ b/rmw_unix_socket_cpp/src/registry.hpp
@@ -18,7 +18,9 @@ namespace rmw_uds
 
 static constexpr uint32_t REGISTRY_MAX_ENTRIES = 32768;
 // Layout v3: per-slot seqlock + atomic state. No global mutex on hot paths.
-static constexpr uint32_t REGISTRY_VERSION = 3;
+// Layout v4: adds a monotonic high_water_slot bound to the header so query and
+// cleanup scan only the used slot prefix instead of all REGISTRY_MAX_ENTRIES.
+static constexpr uint32_t REGISTRY_VERSION = 4;
 
 enum RegistryEntryType : uint8_t
 {
@@ -131,6 +133,10 @@ struct RegistryHeader
   // Robust mutex retained only for the one-time init handshake on shm creation.
   // Hot paths (add / remove / query / cleanup) never take it.
   pthread_mutex_t init_mutex;
+  // Monotonic upper bound on used slot indices: max(idx)+1 ever stored. Lets
+  // query/cleanup scan only [0, high_water_slot) instead of all max_entries.
+  // Only grows; over-scan is always safe, so reads need no strict ordering.
+  std::atomic<uint32_t> high_water_slot;
 };
 
 // Header layout guard: only the integer prefix is asserted. The total size

--- a/rmw_unix_socket_cpp/test/test_registry.cpp
+++ b/rmw_unix_socket_cpp/test/test_registry.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <cstring>
 #include <fcntl.h>
 #include <unistd.h>
@@ -199,6 +200,43 @@ TEST_F(RegistryTest, MultipleEntriesSameType)
 
   for (int32_t idx : indices) {
     rmw_uds::registry_remove(header, idx);
+  }
+}
+
+// The high-water bound must shrink the scan range without dropping the
+// highest-index entry. Adding sequentially from an empty (fresh SetUp)
+// registry fills slots 0..4, so high_water must equal max(idx)+1 = the count.
+// Fails on unmodified main (no high_water_slot member) and on a buggy fix
+// that scans [0, hw) with hw==idx or [0, hw-1).
+TEST_F(RegistryTest, HighWaterBoundsScanWithoutLosingTopEntry)
+{
+  auto * header = rmw_uds::registry_header(registry_ptr);
+  std::vector<int32_t> idx;
+  for (int i = 0; i < 5; ++i) {
+    rmw_uds::RegistryEntry e;
+    std::memset(&e, 0, sizeof(e));
+    e.type = rmw_uds::ENTRY_NODE;
+    e.pid = getpid();
+    std::snprintf(e.node_name, sizeof(e.node_name), "hw_%d", i);
+    int32_t k = rmw_uds::registry_add(header, e);
+    ASSERT_GE(k, 0);
+    idx.push_back(k);
+  }
+
+  // high_water is the count (slots fill 0..4), i.e. max(idx)+1.
+  uint32_t hw = header->high_water_slot.load();
+  EXPECT_EQ(static_cast<uint32_t>(*std::max_element(idx.begin(), idx.end())) + 1, hw);
+  EXPECT_LT(hw, header->max_entries);  // bound far below 32768 -> scan is cheap
+
+  // The top (highest-index) entry must still be found -> guards the [0, hw) vs
+  // [0, hw-1) and idx vs idx+1 off-by-ones.
+  auto top = rmw_uds::registry_query(header, rmw_uds::ENTRY_NODE, nullptr, "hw_4", nullptr);
+  EXPECT_EQ(1u, top.size());
+  auto all = rmw_uds::registry_query(header, rmw_uds::ENTRY_NODE, nullptr, nullptr, nullptr);
+  EXPECT_EQ(5u, all.size());
+
+  for (int32_t k : idx) {
+    rmw_uds::registry_remove(header, k);
   }
 }
 


### PR DESCRIPTION
> NOTE: requires a REGISTRY_VERSION bump (3->4) — needs a coordinated fleet redeploy; do not merge until that flag-day is scheduled.

## What

Adds a monotonic `high_water_slot` field to `RegistryHeader` and uses it to bound the two full-array scans (`registry_query`, `registry_cleanup_stale`) to the used slot prefix `[0, high_water)` instead of iterating all `REGISTRY_MAX_ENTRIES` (32768) slots.

- `try_add_once` bumps `high_water_slot` to `max(current, idx+1)` after committing each entry (relaxed CAS fetch_max loop — no native `fetch_max` in C++17).
- `registry_query` / `registry_cleanup_stale` clamp their loop to `min(high_water_slot, max_entries)` via a single acquire load (not per-slot).

## Why

A perf re-audit of the 200-publisher / all-TRANSIENT_LOCAL workload (one node restarted every 5s) showed ~20% of CPU sitting in the per-slot `std::atomic<uint8_t>::load` of the 32768-slot scan in `registry_query`. In that workload the high-water mark stays near 200-1000, so the scan shrinks ~30-160x.

## Impact

- Discovery query/cleanup cost now scales with the number of slots ever used, not the fixed 32768 ceiling.
- Behavior preserved: the bound only ever grows, so over-scan is always safe and a committed-before-query slot can never be missed. `high_water_slot` stores `idx+1` (the count), so the existing `for (i=0; i<max; ++i)` loops cover exactly the used range with no off-by-one.

## Shared-memory layout change — coordinated redeploy required

The header grows from 56 to 64 bytes (glibc/x86_64, `sizeof(pthread_mutex_t)==40`), shifting the slot-array start, so `REGISTRY_VERSION` bumps 3 -> 4. A v3 process and a v4 process **cannot** share a registry. `registry_open` already reclaims a stale file on size/version mismatch, but a rolling restart can split-brain (the first v4 process recreates the registry while still-running v3 processes keep their old mapping). **All nodes must be restarted together, not rolled.**

The four existing `RegistryHeader` prefix offset asserts (version/max_entries/generation/init_mutex) are unchanged because the new field is appended after `init_mutex`; consistent with the existing convention, no offset/size assert is added for `high_water_slot` (the version bump is the layout guard).

## Test

- New `HighWaterBoundsScanWithoutLosingTopEntry` pins the invariant `high_water == max(idx)+1`, that the bound is far below `max_entries`, and that the top (highest-index) entry is still found — this fails on a buggy `[0, hw-1)` or `hw==idx` off-by-one.
- Existing `MultipleEntriesSameType` (50 entries), `QueryFiltersByType`, `CleanupStaleRemovesDeadPidEntries`, `AddReclaimsStaleSlotsOnOverflow`, `AddOverflowKeepsLivePidEntries`, and the concurrent suite (`ConcurrentAllocateDistinctSlots`, 1600 entries) all guard the bounded scan and pass unchanged. `OpenCreatesValidHeader` covers the 3 -> 4 version bump.