### PR TITLE
chore: prepare for open-source release

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/rmw_unix_socket_cpp/DESIGN.md
+++ b/rmw_unix_socket_cpp/DESIGN.md
@@ -2,6 +2,8 @@
 
 A lightweight, localhost-only RMW (ROS Middleware) implementation for ROS 2 using Unix domain sockets and POSIX shared memory. Designed for single-machine deployments with 200+ nodes and minimal resource usage.
 
+This document is self-contained: it covers every design decision, wire format, synchronization primitive, and operational quirk.
+
 Reference: [ROS 2 Creating an RMW Implementation](https://docs.ros.org/en/rolling/Tutorials/Advanced/Creating-An-RMW-Implementation.html)
 
 ---
@@ -15,12 +17,26 @@ Reference: [ROS 2 Creating an RMW Implementation](https://docs.ros.org/en/rollin
 |  rmw_unix_socket_cpp                                 |
 |  +------------+ +------------+ +-------------------+ |
 |  | Registry   | | Transport  | | Serialization     | |
-|  | (shm)      | | (UDS)      | | (introspection)   | |
+|  | (shm)      | | (UDS)      | | (fastcdr)         | |
 |  +------------+ +------------+ +-------------------+ |
 +-----------------------------------------------------+
 |  Linux Kernel (AF_UNIX, epoll, eventfd, shm, mmap)   |
 +-----------------------------------------------------+
 ```
+
+Each block is one design choice with rationale below.
+
+---
+
+## ABI conventions
+
+These apply everywhere in `src/` and are non-obvious to readers new to the RMW layer.
+
+- **All public entry points are `extern "C"`.** rcl `dlopen`s the RMW shared library and calls fixed C symbols; C++ name mangling would break linkage.
+- **The implementation identifier is compared by pointer, not by `strcmp`.** Every RMW handle carries `implementation_identifier`. We declare it as `inline constexpr char identifier[] = "rmw_unix_socket_cpp";` so it has a single address across all translation units (C++17 guarantee).
+- **No exceptions cross the RMW boundary.** Every public function returns `rmw_ret_t` or a pointer. Exceptions from `fastcdr` are caught at the serialization boundary.
+- **The `void * data` field on every RMW struct holds our private struct** (`UdsNode`, `UdsPublisher`, ...). Defined in `types.hpp`. Recovered by `static_cast` on every entry.
+- **Lock-free registry, mutex-protected per-entity caches.** The shared-memory registry uses a per-slot seqlock + atomic state machine (no global mutex on hot paths). Per-publisher / -client / -service caches use `std::mutex` because they are process-local and rare.
 
 ---
 
@@ -28,71 +44,186 @@ Reference: [ROS 2 Creating an RMW Implementation](https://docs.ros.org/en/rollin
 
 ### 1. Transport: `SOCK_DGRAM` Unix Domain Sockets
 
-**Choice**: All data (topics, service requests, service responses) flows through `SOCK_DGRAM` (datagram) Unix domain sockets.
+**Choice**: All data (topics, service requests, service responses) flows through `SOCK_DGRAM` (datagram) Unix domain sockets in `/tmp/ros2_uds/<domain_id>/`.
 
 **Why not `SOCK_STREAM`?**
-- `SOCK_STREAM` requires connection management (`accept`, `connect`, per-connection fds). For pub/sub with N subscribers this means N connections per publisher, plus framing logic to delimit messages in the byte stream.
-- `SOCK_DGRAM` preserves message boundaries natively -- each `recvmsg()` returns exactly one complete message. This eliminates all framing code.
-- `SOCK_DGRAM` is connectionless -- the publisher simply sends to each subscriber's socket path. No connection setup, no teardown, no state to manage.
+- Stream sockets require connection management (`accept`, `connect`, per-connection fds). For pub/sub with N subscribers this means N connections per publisher, plus framing logic to delimit messages.
+- `SOCK_DGRAM` preserves message boundaries natively — each `recvmsg()` returns exactly one complete message.
+- `SOCK_DGRAM` is connectionless — the publisher simply sends to each subscriber's socket path. No connection setup, no teardown, no state to manage.
 
 **Why not shared memory for data?**
 - Shared memory (e.g., iceoryx) gives zero-copy performance but adds significant complexity: memory pools, slot management, reference counting, flow control.
 - Unix sockets are a single `sendmsg()` / `recvmsg()` call and the kernel handles all buffering, flow control, and backpressure.
-- For localhost communication, Unix sockets are already highly optimized in the Linux kernel (the data never touches a network interface).
+- For localhost the data never touches a network interface.
 
-**Trade-off**: Message size is limited by the socket buffer (default ~212 KB, configured to 48 MB). For truly large messages (point clouds, images), this may require tuning `rmem_max` / `wmem_max` sysctl. This was accepted as the right trade-off for simplicity.
+**Socket asymmetry**:
+- **Subscribers, services, and clients hold bound sockets** in `/tmp/ros2_uds/<domain>/<prefix>_<pid>_<unique>.sock` (prefix = `sub` / `srv` / `cli`). The PID is in the filename so stale-file cleanup can match it against `/proc/<pid>`.
+- **Publishers do not have their own socket.** A single unbound `SOCK_DGRAM` send socket per context is shared by every publisher in the process. Possible because each `sendmsg` supplies the destination address inline (`msg.msg_name`). Saves one fd per publisher.
+
+**Socket-path uniqueness**: `/tmp/ros2_uds/<domain>/<prefix>_<pid>_<atomic_counter_high16 | microseconds_low16>.sock`. The PID guards against host-wide collisions; the counter+timestamp guards against same-PID restarts before the kernel reaps the dying process. The full path stays under 100 bytes (Linux `sockaddr_un.sun_path` limit is 108 bytes).
+
+**Wire format per datagram**: a single `sendmsg` writes a scatter-gather pair (`iovec[2]`) that the kernel concatenates into one datagram:
+
+```
++-------------------------------+--------------------+----------------------+
+| WireHeader (37 bytes, packed) | CDR encap (4 bytes)| CDR body (variable)  |
++-------------------------------+--------------------+----------------------+
+```
+
+`WireHeader` (defined in `types.hpp`, `__attribute__((packed))`):
+
+| Field | Bytes | Purpose |
+|---|--:|---|
+| `gid[16]` | 16 | Sender GID (publisher / requester / responder). |
+| `sequence_number` | 8 | Per-entity monotonic counter. Used to detect drops on the wire. |
+| `source_timestamp_ns` | 8 | Send-side `CLOCK_REALTIME` in ns. |
+| `payload_size` | 4 | Length of the CDR body that follows. |
+| `msg_type` | 1 | `0`=topic, `1`=service request, `2`=service response. |
+
+The 4-byte CDR encapsulation header (`{kind=CDR_LE, options=0x00}`) makes the body byte-compatible with DDS CDR. The reader negotiates endianness off the encap header — mixed-endian setups work even though we only ever target Linux/amd64 today.
+
+**Send flags**: every `sendmsg` uses `MSG_DONTWAIT | MSG_NOSIGNAL`. Non-blocking: if the destination's recv buffer is full we get `EAGAIN` and drop silently (logging at high rates would spam). `MSG_NOSIGNAL` blocks `SIGPIPE` even though it's a belt-and-suspenders for datagram sockets.
+
+**Receive**: a two-step `recv(MSG_PEEK | MSG_TRUNC)` then `recv(MSG_DONTWAIT)`. The first call asks the kernel for the true datagram size without consuming it (`MSG_TRUNC` semantics on `SOCK_DGRAM` are Linux-specific); we resize a `thread_local` 256 KB starter buffer if needed, then consume. This avoids preallocating a max-sized buffer per subscription. The thread-local high-water mark means each executor thread keeps one growing buffer per process lifetime.
+
+**Trade-off**: Per-datagram size is capped by `SO_RCVBUF` / `SO_SNDBUF`. We request 48 MB on every socket via `setsockopt`, but the kernel silently clamps to `net.core.rmem_max` / `net.core.wmem_max`. **Without sysctl tuning these clamp to ~212 KB** — fine for control messages but small images and point clouds will be dropped (`EMSGSIZE` on send). A production deployment can set `rmem_max=wmem_max=48000000` at boot.
+
+**Buffer overflow note**: each Unix datagram socket also has a per-socket queue depth cap from `net.unix.max_dgram_qlen` (default 512 datagrams). On a 150-node fleet, when a new subscriber appears, every publisher in the system can fan out simultaneously and overflow that queue before the new sub gets to drain. Symptom is `EAGAIN` on `sendmsg` with small messages, even though there's no byte-budget pressure. Production deployment bumps this to 4096.
 
 ### 2. Discovery: POSIX Shared Memory Registry
 
-**Choice**: A single shared memory file (`/dev/shm/ros2_uds_<domain_id>`) acts as the discovery registry. Every node, publisher, subscriber, service, and client registers itself here with its socket path.
+**Choice**: A single shared memory file `/dev/shm/ros2_uds_<domain_id>` acts as the discovery registry. Every node, publisher, subscriber, service, and client registers itself here with its socket path.
 
 **Why not a daemon process (like ROS 1's rosmaster)?**
 - A daemon adds a process to manage (start, stop, crash recovery).
-- Shared memory is always available -- no startup ordering issues.
+- Shared memory is always available — no startup ordering issues.
 - Direct memory access is faster than IPC to a daemon for every lookup.
 
 **Why not multicast/broadcast UDP?**
-- This is a localhost-only implementation. Shared memory is the simplest possible IPC for discovery on a single machine.
+- This is a localhost-only implementation. Shared memory is the simplest IPC for discovery on a single machine.
 - No network stack involvement at all.
 
+**File layout**:
+
+```
+struct RegistryHeader {                // 56 bytes
+  std::atomic<uint32_t> version;       // REGISTRY_VERSION = 3
+  uint32_t max_entries;                // REGISTRY_MAX_ENTRIES = 32768
+  std::atomic<uint64_t> generation;    // bumped on every add/remove — cache invalidation tag
+  pthread_mutex_t init_mutex;          // VESTIGIAL — see §3
+};
+
+struct RegistryEntrySlot {             // 1168 bytes
+  std::atomic<uint32_t> seq;           // even = stable, odd = mid-write (seqlock)
+  std::atomic<uint8_t>  state;         // ENTRY_EMPTY / NODE / PUBLISHER / SUBSCRIPTION / SERVICE / CLIENT
+  uint8_t  pad[3];
+  pid_t    pid;                        // owning process — checked via /proc/<pid> for stale cleanup
+  uint8_t  gid[16];
+  char     node_name[256];
+  char     node_namespace[256];
+  char     topic_name[256];            // also reused as service name
+  char     type_name[256];
+  char     socket_path[108];           // matches sockaddr_un.sun_path
+  uint8_t  qos_reliability;
+  uint8_t  qos_durability;
+  uint8_t  qos_history;
+  uint8_t  pad2;
+  uint32_t qos_depth;
+};
+```
+
+Total file size = 56 + 32768 × 1168 ≈ **36.5 MiB**. Mode `0666` so containers running as different UIDs can share it.
+
 **Why a fixed-size layout?**
-- Fixed 8192 entries (each ~1156 bytes, ~9.2 MB total) avoids the complexity of dynamic resizing (`mremap`, pointer invalidation, etc.).
-- 8192 entries comfortably supports 200+ nodes with ~20 endpoints each (4000+ entries) with 2x headroom.
-- The memory is mapped `MAP_SHARED` so all processes see the same data.
+- 32768 entries × ~1168 bytes avoids the complexity of dynamic resizing (`mremap`, pointer invalidation, etc.).
+- Comfortably supports the production target of 150+ nodes with 30+ endpoints each (~5000 entries) with large headroom for fleet growth.
+- The original 8192 limit was hit in production at 151 nodes; the registry was bumped to 32768 and `REGISTRY_VERSION` was incremented (v1 → v2 raised the entry count, v2 → v3 dropped the global mutex). Incompatible files are detected by file-size mismatch on `fstat` after `shm_open`, or by version mismatch during the post-attach spin on `header->version`.
 
-**Stale entry cleanup**: When a process dies without calling the destroy APIs (SIGKILL, OOM, crash, container restart), its registry entries and `/tmp/ros2_uds/<domain>/` socket files are left behind. Cleanup uses `stat("/proc/<pid>")` — if the PID is not visible in the caller's PID namespace, the entry is either from a dead process or from a process we cannot reach anyway, so reclaiming it is safe. Orphan socket files are cleaned the same way: the PID is encoded in the file name (`<prefix>_<pid>_<unique>.sock`), so the same `/proc` check applies.
+**Per-node baseline cost**: an empty `rclcpp::Node` registers **9 entries**: 1 NODE, 1 PUBLISHER (`/parameter_events`), and 7 SERVICEs (the six parameter services plus implicit `~/get_type_description`). At 150 nodes that's ~1350 entries before the first user pub/sub.
 
-Cleanup is triggered at three points:
+**Initialization race**: the first process to `shm_open(O_CREAT | O_EXCL)` becomes the initializer. It `ftruncate`s, zeroes the file, initializes the header, and publishes `header->version = REGISTRY_VERSION` with **release** ordering as the very last step. Late arrivers spin on `version.load(acquire)` for up to ~10000 yields. If we time out with `version == 0`, the creator died mid-init and we best-effort re-init. If `version` is some other non-zero value, the file is stale → `shm_unlink` and retry.
 
-1. **On `rmw_init()`** for each context, right after the registry is opened. Stale registry slots are cleared and orphan socket files in `/tmp/ros2_uds/<domain>/` are unlinked. This is the primary recovery path after ungraceful shutdowns — every process startup scrubs state left by prior crashes.
-2. **On `EOWNERDEAD`** when any process acquires the registry mutex and the previous owner died while holding it (via the robust mutex).
-3. **Inside `registry_add()`** when all slots are full: stale entries are reclaimed and the insertion is retried once before returning "registry full".
+**Stale entry cleanup**: when a process dies without calling the destroy APIs (SIGKILL, OOM, crash, container restart), its registry entries and socket files are left behind. We use `stat("/proc/<pid>")` to test liveness: if the PID is not visible in the caller's PID namespace, the entry is from a dead process (or from a process we cannot reach anyway, so reclaiming is safe). Orphan socket files in `/tmp/ros2_uds/<domain>/` are scrubbed the same way — the PID is encoded in the filename (`<prefix>_<pid>_<unique>.sock`).
 
-No background cleanup thread is needed.
+Cleanup runs at three points:
 
-### 3. Locking: POSIX Robust Mutex
+1. **On `rmw_init()`** for each context: `registry_cleanup_stale()` + `cleanup_orphan_socket_files()`. This is the primary recovery path after ungraceful shutdowns.
+2. **On every discovery query** (`rmw_get_node_names`, `rmw_get_topic_names_and_types`, etc.): each call walks the registry through `query_all()`, which calls `registry_cleanup_stale()` as a side effect. So CLI tools (`ros2 node list`, `ros2 topic list`) are self-healing.
+3. **Inside `registry_add()`** when all 32768 slots are full: stale entries are reclaimed and the insertion is retried once before returning "registry full".
 
-**Choice**: A `pthread_mutex_t` with `PTHREAD_PROCESS_SHARED` and `PTHREAD_MUTEX_ROBUST` attributes, stored in the shared memory header.
+No background cleanup thread is needed. **There is no `EOWNERDEAD` path** — that would require a robust mutex on the hot paths, and we don't have one (see §3).
 
-**Why not file locks (`flock`/`fcntl`)?**
-- File locks cannot atomically protect shared memory operations.
-- Process-shared mutexes integrate naturally with `mmap`'d memory.
+**Container caveat**: cleanup correctness depends on every process seeing the same PID namespace. If container A reclaims slots whose PIDs belong to container B (because B's PIDs are `ENOENT` in A's `/proc`), the registry is corrupted. Production deployments run all containers with `--pid=host` for this reason. `--ipc=host` and a bind mount of `/tmp/ros2_uds/` are also required so all containers see the same `/dev/shm` and socket files.
 
-**Why robust mutexes?**
-- If a process holding the mutex crashes, the next process to lock it receives `EOWNERDEAD` and can call `pthread_mutex_consistent()` to recover.
-- Without robust mutexes, a crashed lock-holder would permanently deadlock all other processes.
+### 3. Locking: Per-slot seqlock + atomic state machine (lock-free)
+
+**Choice**: Hot paths (add / remove / query / cleanup) use a per-slot seqlock plus an atomic state CAS. **There is no global mutex on the hot path.** The `init_mutex` field in the header is initialized as a `PTHREAD_PROCESS_SHARED | PTHREAD_MUTEX_ROBUST` mutex for historical reasons but is **never locked anywhere in the code** — it is vestigial and kept only because removing it would change the header size and bump `REGISTRY_VERSION` again.
+
+**Why we abandoned the global mutex (v1/v2 → v3)**: at ~150 nodes in production, every `rmw_publish` / `rmw_send_request` / `rmw_send_response` was serializing through a single mutex to look up destination paths. End-to-end latency rose to ~500 ms. The fix had two parts: per-publisher caches keyed off a generation counter (§8a) and a lock-free registry so cache misses also don't take a lock.
+
+**Per-slot state machine**:
+
+```
+state == ENTRY_EMPTY
+   │
+   │  writer: CAS(state, EMPTY -> target_type)
+   ▼
+state == <type>      // payload protected by seqlock
+   │
+   │  remover: CAS(state, <type> -> EMPTY)
+   ▼
+state == ENTRY_EMPTY
+```
+
+Only one party can win the CAS in either direction. Losers retry or move on. No locks.
+
+**Per-slot seqlock**: the atomic `state` is enough to claim ownership of a slot, but the payload (pid, gid, node_name, topic_name, socket_path, ...) is non-atomic and bigger than any CAS can cover. We protect it with a seqlock — the classical Linux-kernel `seqcount_t` pattern, applied per slot:
+
+```
+writer (after winning state CAS):
+  1. seq.fetch_add(1, acq_rel)   ->  seq becomes odd (write in progress)
+  2. memcpy payload fields
+  3. seq.fetch_add(1, acq_rel)   ->  seq becomes even (snapshot stable)
+
+reader:
+  1. s1 = seq.load(acquire); if (s1 & 1) writer in progress -> yield + retry
+  2. st = state.load(acquire); if EMPTY -> skip slot
+  3. memcpy payload into a local snapshot
+  4. s2 = seq.load(acquire); if s1 == s2 -> success, else retry
+```
+
+Bounded at 16 retries (`MAX_READ_RETRIES`) so a pathological writer cannot starve readers forever. A reader that gives up just returns "slot was unstable" — the caller treats it as not-found and the next iteration tries again.
+
+**Why this is safe across processes**: the atomics live in a `MAP_SHARED` mmap. Static asserts at compile time check that `std::atomic<u8/u32/u64>::is_always_lock_free` is `true`. Lock-freedom on x86/ARM implies "address-free" — the implementation is a single CAS/load/store instruction with no helper state outside the memory location — which is the requirement for cross-process atomics on the same physical page.
+
+**Why not file locks (`flock` / `fcntl`)?** File locks cannot atomically protect arbitrary shared-memory operations, and they would be per-fd / per-process state outside the mmap.
+
+**Memory ordering summary**:
+
+| Operation | Order |
+|---|---|
+| Writer claims slot (state CAS) | `acq_rel` success, `relaxed` failure |
+| Writer begin/end payload (`seq.fetch_add`) | `acq_rel` |
+| Writer ends with `generation.fetch_add` | `acq_rel` |
+| Reader pre-check `state.load` | `acquire` |
+| Reader begin/end `seq.load` | `acquire` |
+| `version` publish on init | `release` |
+| `version` attach-wait load | `acquire` |
+| `registry_generation` load | `acquire` |
+
+The acquire/release pairs guarantee that a reader who observes `version == REGISTRY_VERSION` also observes the post-init zero-fill of the slot array, and that a reader who observes a `generation` bump observes all preceding slot writes.
 
 ### 4. Serialization: CDR via `fastcdr` + `rosidl_typesupport_fastrtps`
 
-**Choice**: Use the eProsima `fastcdr` library with `rosidl_typesupport_fastrtps_cpp` generated callbacks for CDR serialization. This is the same approach used by `rmw_zenoh_cpp`.
+**Choice**: Use the eProsima `fastcdr` library with `rosidl_typesupport_fastrtps_cpp` generated callbacks for CDR serialization. Same approach as `rmw_fastrtps_cpp` (the default ROS 2 RMW), `rmw_zenoh_cpp`, and `rmw_connextdds`.
 
 **How it works**:
 - Each ROS message type has generated `cdr_serialize()` / `cdr_deserialize()` functions provided by `rosidl_typesupport_fastrtps_cpp`.
-- At publisher/subscription creation, we resolve the `message_type_support_callbacks_t` from the type support handle.
+- At publisher/subscription creation, we resolve the `message_type_support_callbacks_t` from the type support handle. If the C++ variant isn't present we fall back to the C variant (`rosidl_typesupport_fastrtps_c`).
 - `rmw_publish` calls `callbacks->cdr_serialize(ros_message, cdr)` — compiled per-message-type code, no runtime field walking.
 - `rmw_take` calls `callbacks->cdr_deserialize(cdr, ros_message)` — same compiled code in reverse.
 
-**Why this approach was chosen (and what we tried first)**:
+**Why fastcdr (and what we tried first)**:
 
 We originally implemented a custom introspection-based serializer that walked message fields at runtime using `rosidl_typesupport_introspection_cpp::MessageMembers`. This failed in production for several reasons:
 
@@ -107,23 +238,41 @@ We originally implemented a custom introspection-based serializer that walked me
 **Why fastcdr solves all of this**:
 - Uses **compiled per-message-type code** — no runtime introspection walking, no C/C++ ABI issues.
 - Handles all message types correctly: nested sequences, strings, bools, wstrings, bounded sequences.
-- Battle-tested: used by `rmw_fastrtps_cpp` (default ROS 2 RMW), `rmw_zenoh_cpp`, and `rmw_connextdds`.
-- Only ~130 lines of serialization code (vs ~400 lines for the introspection approach).
+- Battle-tested by every major DDS-based RMW.
+- ~130 lines of serialization code vs ~400 lines for the introspection approach.
 
-**Dependencies added**: `fastcdr`, `rosidl_typesupport_fastrtps_c`, `rosidl_typesupport_fastrtps_cpp`. These are standard ROS 2 packages installed with any ROS 2 distribution.
+**Dependencies added**: `fastcdr`, `rosidl_typesupport_fastrtps_c`, `rosidl_typesupport_fastrtps_cpp`. These ship with every ROS 2 distribution.
 
 ### 5. Wait Mechanism: `epoll` + `eventfd`
 
-**Choice**: `rmw_wait()` uses `epoll_wait()` to block on subscription socket fds, service/client socket fds, and guard condition `eventfd`s.
+**Choice**: `rmw_wait()` uses `epoll_wait()` to block on subscription socket fds, service/client socket fds, and guard-condition eventfds.
 
 **Why `epoll` instead of `poll`/`select`?**
-- `epoll` is O(1) with respect to the number of watched fds, while `poll`/`select` are O(n).
-- With 200+ nodes and many subscriptions, the fd count can be high. `epoll` handles thousands of fds efficiently.
+- `epoll` is O(1) with respect to the number of watched fds; `poll`/`select` are O(n).
+- With 200+ nodes and many subscriptions, the fd count can exceed a thousand. `epoll` handles it efficiently.
 
 **Why `eventfd` for guard conditions?**
-- `eventfd` is the lightest possible signaling primitive in Linux (a single 8-byte kernel counter).
-- It integrates directly with `epoll` -- no pipe pair needed.
-- Writing `1` triggers it, reading it consumes the trigger. Perfect for the guard condition pattern.
+- `eventfd` is the lightest possible signaling primitive in Linux: a single 8-byte kernel counter.
+- It integrates directly with `epoll` — no pipe pair needed.
+- Writes increment the counter; reads consume it. Coalescing is automatic: 100 triggers between two reads coalesce into "counter was non-zero".
+- Created with `EFD_NONBLOCK` so reads return `EAGAIN` instead of blocking.
+- **Intra-process only.** An eventfd has no cross-process meaning. All guard conditions are signaled within a single process; cross-process graph events are polled via the registry's `generation` counter, not pushed via eventfd (see §10).
+
+**`rmw_wait` flow**:
+
+1. **Pre-drain**: drain every subscription / service / client socket into per-entity message queues. Catches data that arrived while the executor was busy.
+2. **Ready check**: if any entity has a queued message ready, return immediately without blocking.
+3. **Register fds with epoll** (additively, see below) and block in `epoll_wait` for up to the caller's timeout.
+4. **Post-drain**: drain everything again after wake-up.
+5. **Mark ready entities** in the wait set so rcl can dispatch them.
+
+This drain-three-times pattern (pre, post, and again inside each `rmw_take`) is intentional and defensive: rcl makes no guarantees about when between wait-and-take a callback runs, and we want zero data loss.
+
+**Persistent epoll registration**: an early version called `EPOLL_CTL_ADD` for every fd at the start of every wait, then `EPOLL_CTL_DEL` at the end — two syscalls per fd per wait, pure overhead under a tight executor loop. The current implementation tracks `registered_fds` (a `std::set<int>` in `UdsWaitSet`) and only `EPOLL_CTL_ADD`s fds we haven't seen before. We never `EPOLL_CTL_DEL` — the kernel automatically removes a fd from epoll when it's closed (`man epoll`, Q6).
+
+**Trade-off**: a wait set "remembers" every fd it has ever observed. This is fine because (a) the kernel already cleaned up the fd at `close()` time, (b) the set is bounded by the number of distinct fds the process ever creates, which is bounded by the file-descriptor ulimit. There is a theoretical risk if fd numbers are recycled by a brand-new entity the wait set didn't know about — in practice it has never manifested.
+
+**Timeout granularity**: epoll's timeout is in milliseconds. A caller passing `nsec > 0` is rounded up to 1 ms minimum. Typical 50–200 Hz control loops don't care about sub-ms precision; if they did, we'd need `timerfd` instead.
 
 ### 6. No Background Threads
 
@@ -133,25 +282,36 @@ We originally implemented a custom introspection-based serializer that walked me
 - Background threads introduce lock contention on message queues.
 - Thread management (creation, shutdown, error handling) adds complexity.
 - The ROS 2 executor model already calls `rmw_wait()` in a tight loop. Draining sockets at this point is natural and sufficient.
-- This is the same approach used by `rmw_zenoh_cpp`.
+- Same approach as `rmw_zenoh_cpp`.
 
-**How it works**:
-1. At the start of `rmw_wait()`, drain all subscription/service/client sockets into per-entity message queues.
-2. Check if any entity already has data ready. If yes, return immediately.
-3. If nothing is ready, register all fds with `epoll` and block.
-4. After `epoll_wait()` returns, drain sockets again and report which entities are ready.
+This is what makes the resource footprint deterministic — the process never has phantom threads holding fds or memory.
 
-### 7. QoS Simplification
+### 7. QoS: what we enforce and what we accept-but-ignore
 
-**Choice**: All QoS policies are simplified:
-- `RELIABLE` and `BEST_EFFORT` are treated identically (Unix sockets don't drop messages on localhost).
-- `TRANSIENT_LOCAL` is not supported (no late-joining replay).
-- `KEEP_LAST` with configurable depth is the only history mode.
+**Choice**: implement the QoS policies whose semantics actually differ on a localhost-only transport; accept (but do not differentiate) the rest.
 
-**Why?**
-- Unix domain sockets provide reliable, in-order delivery by the kernel. There is no network loss to protect against.
-- Implementing `TRANSIENT_LOCAL` would require storing published messages persistently, adding significant complexity.
-- These simplifications cover the vast majority of ROS 2 use cases.
+| QoS policy | Behavior |
+|---|---|
+| `history` = KEEP_LAST | **Enforced.** Subscription queue capped at QoS `depth`. Oldest messages dropped when full. |
+| `history` = KEEP_ALL | **Treated as KEEP_LAST with depth=10.** Unbounded queues are not supported. |
+| `depth` | **Enforced.** Controls both subscription queue size and TRANSIENT_LOCAL publisher cache size. |
+| `durability` = VOLATILE | **Enforced.** Publisher doesn't cache. Late-joining subscribers miss past messages. |
+| `durability` = TRANSIENT_LOCAL | **Enforced.** Publisher caches the last `depth` messages in a `std::deque<CachedMessage>`. Replay to late-joining subscribers fires through **two paths**: (1) inside `rmw_publish`, after appending the new message, replaying `message_cache[0 .. size-2]` to any new path (the most recent entry is the about-to-be-sent live message, delivered by the live publish loop below); (2) inside `rmw_wait`, on registry `generation` change, replaying the **entire** `message_cache` to any new path — because no live publish is following. Both paths cooperate via `known_subscriber_paths` (a per-publisher `std::set<std::string>`): whichever runs first marks the path, the other becomes a no-op. The wait-path is what makes a publisher that publishes once at startup and stays idle still serve cached messages to subscribers that join later. `known_subscriber_paths` grows monotonically — if a subscriber dies its path is reclaimed but the set entry remains (bounded by total subscribers ever seen on that topic in this process). To support the wait-path, every TRANSIENT_LOCAL publisher is registered in `UdsContext::transient_local_pubs` at create time, removed at destroy, and the mutex protecting that list is held across the whole `rmw_wait` iteration so concurrent destroys can't free a publisher mid-iteration. |
+| `reliability` = RELIABLE | **Accepted, not differentiated.** Unix sockets are inherently reliable on localhost (kernel doesn't drop unless `SO_RCVBUF` overflows). |
+| `reliability` = BEST_EFFORT | **Accepted, not differentiated.** Identical to RELIABLE on this transport. |
+| `deadline` | **Not enforced.** Accepted but ignored. Would require a timer thread to monitor delivery intervals. |
+| `lifespan` | **Not enforced.** Accepted but ignored. Would require timestamped expiration checks on every message. |
+| `liveliness` | **Not enforced.** Accepted but ignored. Would require periodic heartbeat checking. |
+| `liveliness_lease_duration` | **Not enforced.** |
+
+**QoS compatibility check** (`rmw_qos_profile_check_compatible`):
+
+| Publisher | Subscriber | Result | Reason |
+|---|---|---|---|
+| BEST_EFFORT | RELIABLE | Warning | Subscriber expects reliable delivery but publisher offers best-effort. Identical on this transport, but flagged as intent mismatch. |
+| VOLATILE | TRANSIENT_LOCAL | Warning | Subscriber expects late-joining replay but publisher doesn't cache. The subscriber will never receive past messages. |
+
+All other combinations return `RMW_QOS_COMPATIBILITY_OK`.
 
 ### 8. Publisher-to-Subscriber Fanout
 
@@ -159,28 +319,56 @@ We originally implemented a custom introspection-based serializer that walked me
 
 **Why not a central router?**
 - A router process adds latency (extra hop), complexity (another process to manage), and a single point of failure.
-- Direct publisher-to-subscriber communication is simpler and has lower latency.
-- The registry lookup is cheap (shared memory scan) and only needs to find matching socket paths.
+- Direct publisher-to-subscriber communication has lower latency.
 
-**Trade-off**: Each subscriber gets its own copy of the message. With N subscribers, the publisher makes N `sendmsg()` calls. For high-fanout topics (>50 subscribers to the same topic), this could become a bottleneck. Acceptable for the 200-node target.
+**Trade-off**: Each subscriber gets its own copy. With N subscribers the publisher makes N `sendmsg()` calls. For very high-fanout topics (>50 subs to the same topic) this could become a bottleneck. Acceptable for the 200-node target.
+
+### 8a. Generation-keyed discovery cache (hot-path optimization)
+
+**Problem**: Once the production system reached ~150 nodes, every `rmw_publish`, `rmw_send_request`, and `rmw_send_response` was contending for a single registry mutex (the v1/v2 layout) to look up destination socket paths. End-to-end latency rose to ~500 ms because dozens of publishers were serializing through one lock.
+
+**Choice**: Each publisher, client, and service caches its discovery results, keyed off the registry's monotonically-increasing `generation` counter. The cache is invalidated only when the topology actually changes.
+
+**How it works**:
+- The registry header has an `std::atomic<uint64_t> generation`, bumped whenever an entry is added or removed.
+- Each `UdsPublisher` stores `(cached_generation, cached_subscriber_paths)`.
+- On publish, we read the current generation with a single relaxed-acquire atomic load. If it matches `cached_generation`, we send to the cached paths immediately — zero mutex acquisitions, zero registry scans.
+- If the generation changed, we lock the per-publisher cache mutex (cheap, uncontended), call `registry_query` (now itself lock-free thanks to §3), refresh the cache, and publish.
+- Same pattern for `UdsClient` (caches the resolved service socket path) and `UdsService` (caches a `GID -> socket_path` map for routing responses).
+
+**Why this is safe**:
+- The generation counter only increases. A stale cache means we either (a) miss a brand-new subscriber — fine, they'll get the next message after the cache refreshes — or (b) try to send to a socket file that no longer exists. Case (b) is harmless: `sendto` returns `ENOENT`, which we silently swallow, and the next publish refreshes the cache.
+- The atomic load on `generation` is the only cross-process synchronization needed for the fast path.
+
+**Result**: Publish/take latency on a 150-node fleet drops from hundreds of milliseconds back to the tens-of-microseconds range that the kernel's UDS path actually delivers.
 
 ### 9. Service Implementation
 
-**Choice**: Services use the same `SOCK_DGRAM` transport as topics. The client sends a request to the service server's socket. The service server sends the response back to the client's socket (looked up from the registry by GID).
+**Choice**: Services use the same `SOCK_DGRAM` transport and the same `WireHeader` as topics. The client sends a request (`msg_type=1`) to the service server's socket; the server sends the response (`msg_type=2`) back to the client's socket, looked up from the registry by client GID.
 
 **Why DGRAM instead of STREAM for services?**
-- Keeps the implementation uniform -- one transport mechanism for everything.
+- Keeps the implementation uniform — one transport for everything.
 - Avoids connection management complexity.
 - Service requests/responses are typically small and fit easily in a single datagram.
 
+**Routing**: the server caches a `(gid, socket_path)` map of every client it has seen. When `rmw_send_response` is called with a response and the client's GID, the server looks up the path and `sendmsg`s. Same generation-keyed invalidation as §8a.
+
+**Service-server availability** (`rmw_service_server_is_available`): a registry walk. No active probing or ping. Cheap because the registry walk is lock-free.
+
+**Multiple services with the same name**: first-match-wins. Deterministic but not round-robin (DDS does load-balance across matching servers; we don't). In practice production has exactly one server per service.
+
+**Request queue depth**: **not enforced.** Unlike subscriptions, services drain the bound socket into an unbounded `std::deque<ReceivedMessage>`. Back-pressure comes from the kernel: when the service's `SO_RCVBUF` fills, the client's `sendmsg` returns `EAGAIN`. We could enforce a per-service depth but it has never been a problem in practice.
+
 ### 10. Graph Guard Condition
 
-**Choice**: The shared memory registry has a `generation` counter that increments on every add/remove. Each `rmw_wait()` call checks this counter. If it changed, the node's graph guard condition is triggered.
+**Choice**: The shared memory registry has a `generation` counter that increments on every add/remove. Each `rmw_wait()` call snapshots the counter; if it changed since the last wait, the **per-node** graph guard conditions are triggered, waking executors that registered for graph events.
 
 **Why poll instead of push?**
-- Push notification across processes without a daemon requires complex IPC (signals, pipes per-process, etc.).
-- Polling the generation counter in `rmw_wait()` is a single atomic load from shared memory.
-- Since `rmw_wait()` is called very frequently by the ROS 2 executor, graph changes are detected within milliseconds.
+- Push notification across processes without a daemon requires complex IPC (signals, a shared eventfd per node, etc.).
+- Polling the generation counter is one atomic load per wait call.
+- `rmw_wait` is called very frequently by the executor; graph changes are detected within milliseconds.
+
+**Implementation note**: there is also a `graph_guard_condition` field on the context. It is currently dead code — per-node guard conditions cover every observed use case, and the context-level GC was never wired up by any caller. We keep the field for ABI completeness.
 
 ### 11. GID Generation
 
@@ -189,21 +377,22 @@ We originally implemented a custom introspection-based serializer that walked me
 **Why this scheme?**
 - Guaranteed unique on a single machine (different PIDs for different processes, monotonic counter within a process).
 - No UUID library dependency.
-- 16 bytes matches `RMW_GID_STORAGE_SIZE` required by the RMW API.
+- 16 bytes matches `RMW_GID_STORAGE_SIZE`.
 
 ### 12. Build System
 
 **Choice**: `ament_cmake` with `configure_rmw_library()` and `register_rmw_implementation()`.
 
-**Dependencies**: Only standard ROS 2 packages + Linux kernel APIs:
+**Dependencies**: only standard ROS 2 packages + Linux kernel APIs:
 - `rmw` (abstract interface)
-- `rcutils`, `rcpputils` (utilities)
-- `rosidl_typesupport_introspection_c/cpp` (message introspection)
+- `rcutils`, `rcpputils` (utilities, logging)
+- `rosidl_typesupport_fastrtps_c` / `rosidl_typesupport_fastrtps_cpp` (CDR callbacks)
+- `fastcdr` (serialization)
 - `pthread`, `rt` (POSIX threading, shared memory)
 
 **Why no external middleware?**
-- The entire point is to avoid heavy middleware like DDS.
-- All functionality is implemented using Linux kernel primitives that are always available.
+- The whole point is to avoid heavy middleware like DDS.
+- Discovery, transport, wait, and serialization are all built on Linux primitives or per-type generated code.
 
 ---
 
@@ -211,24 +400,25 @@ We originally implemented a custom introspection-based serializer that walked me
 
 | File | Purpose |
 |------|---------|
-| `identifier.hpp` | Implementation identifier string |
-| `types.hpp` | All internal C++ data types |
-| `registry.hpp/cpp` | Shared memory discovery registry |
-| `serialization.hpp/cpp` | Introspection-based message serializer |
-| `transport.hpp/cpp` | Unix socket send/receive helpers |
-| `rmw_init.cpp` | Context initialization and shutdown |
-| `rmw_node.cpp` | Node create/destroy |
-| `rmw_publisher.cpp` | Publisher create/destroy/publish |
-| `rmw_subscription.cpp` | Subscription create/destroy/take |
-| `rmw_service.cpp` | Service server |
-| `rmw_client.cpp` | Service client |
-| `rmw_guard_condition.cpp` | Guard conditions (eventfd) |
-| `rmw_wait.cpp` | Wait set (epoll) |
-| `rmw_graph.cpp` | Graph introspection queries |
-| `rmw_event.cpp` | Event stubs |
-| `rmw_serialize.cpp` | Public serialize/deserialize API |
-| `rmw_features.cpp` | Feature queries, identifier, QoS |
-| `rmw_unsupported.cpp` | Unsupported feature stubs |
+| `identifier.hpp` | Implementation identifier (single inline `constexpr char[]`). |
+| `types.hpp` | All internal C++ data types (`UdsContext`, `UdsNode`, `UdsPublisher`, `UdsSubscription`, `UdsService`, `UdsClient`, `UdsWaitSet`, `WireHeader`, ...). |
+| `registry.hpp/cpp` | Shared memory discovery registry, seqlock + atomic state machine, stale-PID cleanup. |
+| `transport.hpp/cpp` | Unix socket send/receive helpers, socket-file lifecycle, orphan cleanup. |
+| `serialization.hpp/cpp` | CDR serialization wrappers around fastcdr callbacks. |
+| `logging.hpp` | `rcutils`-backed logging macros used throughout. |
+| `rmw_init.cpp` | Context initialization, registry open, send-socket creation, shutdown. |
+| `rmw_node.cpp` | Node create/destroy and graph-guard-condition accessor. |
+| `rmw_publisher.cpp` | Publisher create/destroy/publish, generation-keyed cache, TRANSIENT_LOCAL replay. |
+| `rmw_subscription.cpp` | Subscription create/destroy/take, queue, `on_new_message` callback. |
+| `rmw_service.cpp` | Service server. |
+| `rmw_client.cpp` | Service client. |
+| `rmw_guard_condition.cpp` | Eventfd-backed guard condition. |
+| `rmw_wait.cpp` | epoll-based wait set, drain/ready/block/drain. |
+| `rmw_graph.cpp` | Discovery / introspection queries — all reduce to lock-free registry walks. |
+| `rmw_event.cpp` | Event stubs — events are accepted but never generated. |
+| `rmw_serialize.cpp` | Standalone serialize/deserialize APIs. |
+| `rmw_features.cpp` | Identifier query, feature flags, QoS-compatibility check. |
+| `rmw_unsupported.cpp` | All APIs that return `RMW_RET_UNSUPPORTED`. |
 
 ---
 
@@ -236,15 +426,34 @@ We originally implemented a custom introspection-based serializer that walked me
 
 | Resource | Usage |
 |----------|-------|
-| Shared memory | ~9.2 MB (fixed, one per domain) |
-| Socket per subscriber | 1 fd + 1 file in `/tmp/ros2_uds/` |
-| Socket per service/client | 1 fd + 1 file each |
-| Send socket per context | 1 fd (shared by all publishers) |
+| Shared memory | ~36.5 MiB per domain (fixed, one file per `ROS_DOMAIN_ID`) |
+| Socket per subscription | 1 fd + 1 file in `/tmp/ros2_uds/<domain>/` |
+| Socket per service / client | 1 fd + 1 file each |
+| Send socket per context | 1 fd (shared by all publishers in the process) |
 | epoll fd per wait set | 1 fd |
 | eventfd per guard condition | 1 fd |
 | Background threads | **0** |
+| Registry entries per minimal node | 9 (node + parameter_events publisher + 7 services) |
 
-For 200 nodes with 10 pub + 10 sub each: ~4000 registry entries, ~2000 socket files, ~2000 fds total across all processes.
+For 200 nodes with 10 pub + 10 sub each: ~4000 registry entries from user pub/sub, ~1800 from node baselines, ~2000 socket files, ~2000 fds total across all processes.
+
+---
+
+## Operational requirements
+
+Required system tuning for a production deployment. Without these, you will hit transient drops and silent buffer clamps under load.
+
+| Knob | Default | Recommended | Why |
+|---|--:|--:|---|
+| `net.core.rmem_max` | ~212 KB | 48 MB+ | Caps `SO_RCVBUF`. We request 48 MB; without this we get ~212 KB and large messages drop. |
+| `net.core.wmem_max` | ~212 KB | 48 MB+ | Same for `SO_SNDBUF`. Especially relevant for `EMSGSIZE` on point clouds. |
+| `net.unix.max_dgram_qlen` | 512 | 4096 | Per-Unix-dgram-socket pending-datagram cap. Bursty fan-out (e.g. a new node appearing on a 150-node fleet) overflows 512 with small messages. |
+| `ulimit -n` (`nofile`) | 1024 | 65536 | Each pub/sub/service/client takes 1–2 fds. A 150-node fleet exceeds 1024 quickly. |
+
+Docker requirements:
+- `--ipc=host` — for `/dev/shm` sharing
+- `--pid=host` — for cross-container stale-PID cleanup correctness
+- `-v /tmp/ros2_uds:/tmp/ros2_uds` — for socket file sharing
 
 ---
 
@@ -270,70 +479,32 @@ ros2 run demo_nodes_cpp listener
 
 | Limitation | Detail | Why |
 |---|---|---|
-| **Localhost only** | No network communication | This RMW is designed for single-machine deployments. Unix domain sockets (`AF_UNIX`) are local-only by definition. For network communication, use CycloneDDS or Zenoh. |
-| **Message size limit** | Default 48 MB per datagram | Constrained by `SOCK_DGRAM` socket buffer. Tunable via `net.core.wmem_max` / `net.core.rmem_max` sysctl. Point clouds and images may exceed this. |
-| **Linux only** | Not portable to macOS or Windows | Uses Linux-specific kernel APIs: `epoll` (wait), `eventfd` (guard conditions), `/dev/shm` (shared memory registry), `AF_UNIX` (transport). |
-| **Docker requires shared IPC** | Containers must share `/dev/shm` and `/tmp/ros2_uds/` | The shared memory registry lives in `/dev/shm/ros2_uds_<domain_id>` and socket files live in `/tmp/ros2_uds/`. Both must be visible to all containers. Use `--ipc=host` plus `-v /tmp/ros2_uds:/tmp/ros2_uds`. |
-| **Docker PID namespace** | Use `--pid=host` when sharing `/tmp/ros2_uds/` across containers | Stale-entry cleanup uses `stat("/proc/<pid>")`. PIDs outside the caller's namespace are invisible, so without `--pid=host` a container's cleanup pass would unlink entries and socket files owned by processes in other containers. With `--pid=host` (required anyway alongside `--ipc=host` and the `/tmp/ros2_uds` bind mount for cross-container communication), PIDs are unified and cleanup is correct. |
-| **No DDS interoperability** | Cannot communicate with DDS-based RMW implementations | All nodes on the machine must use `rmw_unix_socket_cpp`. Cannot mix with CycloneDDS, FastDDS, or Connext nodes. |
+| **Localhost only** | No network communication | This RMW is designed for single-machine deployments. `AF_UNIX` is local-only by definition. For network communication use CycloneDDS or Zenoh. |
+| **Message size limit** | Tunable via sysctl; defaults to ~212 KB | Capped by `SO_SNDBUF` / `SO_RCVBUF` which are themselves capped by `wmem_max` / `rmem_max`. Point clouds and images may exceed defaults. |
+| **Linux only** | Not portable to macOS or Windows | Uses Linux-specific kernel APIs: `epoll`, `eventfd`, `/dev/shm`, `AF_UNIX`. |
+| **Docker requires shared IPC, PID, and `/tmp` mount** | See *Operational requirements* | Cross-container discovery and stale-PID cleanup correctness require unified namespaces. |
+| **No DDS interoperability** | Cannot communicate with DDS-based RMW implementations | All nodes on the machine must use `rmw_unix_socket_cpp`. |
 
 ### Functions that return `RMW_RET_UNSUPPORTED`
 
-These functions are part of the RMW API but cannot be implemented with Unix socket transport. They return `RMW_RET_UNSUPPORTED` per the RMW specification, which tells rcl/rclcpp to skip the feature gracefully.
+These are part of the RMW API but cannot be implemented with Unix socket transport. They return `RMW_RET_UNSUPPORTED` per the RMW specification, which tells rcl/rclcpp to skip the feature gracefully.
 
 | Function(s) | Feature | Why unsupported |
 |---|---|---|
-| `rmw_borrow_loaned_message` | **Zero-copy loaned messages** | Loaned messages require shared memory between publisher and subscriber so both can access the same memory region without copying. Unix sockets copy data through kernel buffers (`sendmsg`/`recvmsg`). Zero-copy requires a shared-memory transport like iceoryx. |
-| `rmw_publish_loaned_message` | | Same as above. |
-| `rmw_take_loaned_message` | | Same as above. |
-| `rmw_take_loaned_message_with_info` | | Same as above. |
-| `rmw_return_loaned_message_from_publisher` | | Same as above. |
-| `rmw_return_loaned_message_from_subscription` | | Same as above. |
-| `rmw_take_dynamic_message` | **Dynamic message types** | Dynamic type support requires the middleware to discover message types at runtime from remote endpoints and populate `rosidl_dynamic_typesupport_dynamic_data_t` structs. This requires a type discovery protocol (like DDS Type Object) which our simple registry doesn't provide. |
-| `rmw_take_dynamic_message_with_info` | | Same as above. |
-| `rmw_serialization_support_init` | | Same as above — initializes the dynamic type serialization framework. |
-| `rmw_publisher_get_network_flow_endpoints` | **Network flow endpoints** | Returns IP address and port information for QoS tracing. `AF_UNIX` sockets have no IP addresses or ports — they use filesystem paths. There is no meaningful network flow endpoint to report. |
-| `rmw_subscription_get_network_flow_endpoints` | | Same as above. |
-| `rmw_subscription_set_content_filter` | **Content filtering** | Content filtering evaluates a SQL-like expression on each message before delivery to the subscriber. This requires either middleware-level filtering (DDS content-filtered topics) or a filter evaluation engine. Not implemented to keep the RMW simple. All subscribers receive all messages. |
-| `rmw_subscription_get_content_filter` | | Same as above. |
-| `rmw_event_set_callback` | **Event callbacks** | Setting callbacks on events (QoS violations, matched events). Events are initialized successfully (to prevent crashes when rcl adds them to wait sets) but no events are ever generated. `rmw_event_type_is_supported` returns `false` for all event types. |
+| `rmw_borrow_loaned_message`, `rmw_publish_loaned_message`, `rmw_take_loaned_message`, `rmw_take_loaned_message_with_info`, `rmw_return_loaned_message_from_publisher`, `rmw_return_loaned_message_from_subscription` | **Zero-copy loaned messages** | Require shared memory between publisher and subscriber so both can access the same memory region. Unix sockets copy through kernel buffers. Zero-copy needs an iceoryx-style transport. |
+| `rmw_take_dynamic_message`, `rmw_take_dynamic_message_with_info`, `rmw_serialization_support_init` | **Dynamic message types** | Require a runtime type-discovery protocol (DDS Type Object). Our registry doesn't carry per-field schema information. |
+| `rmw_publisher_get_network_flow_endpoints`, `rmw_subscription_get_network_flow_endpoints` | **Network flow endpoints** | Return IP/port for QoS tracing. `AF_UNIX` sockets have neither. |
+| `rmw_subscription_set_content_filter`, `rmw_subscription_get_content_filter` | **Content filtering** | DDS evaluates SQL-like expressions per message. Not implemented. All subscribers receive all messages. |
+| `rmw_event_set_callback` | **Event callbacks** | Events are initialized successfully (to prevent crashes when rcl adds them to wait sets) but never generated. `rmw_event_type_is_supported` returns `false` for all event types. |
 
 ### Functions that return `RMW_RET_OK` but are no-ops
 
-These functions succeed silently but don't do anything. This is intentional — the RMW spec allows implementations to accept but not enforce certain features.
+The RMW spec allows implementations to accept but not enforce certain features.
 
 | Function(s) | Feature | Why no-op |
 |---|---|---|
-| `rmw_init_publisher_allocation` / `rmw_fini_publisher_allocation` | **Pre-allocated publishing** | Our serialization allocates dynamically per-publish (via `fastcdr`). Pre-allocation hints are accepted but ignored. |
-| `rmw_init_subscription_allocation` / `rmw_fini_subscription_allocation` | **Pre-allocated taking** | Same as above — allocation hints are accepted but ignored. |
-| `rmw_publisher_assert_liveliness` | **Manual liveliness assertion** | We don't track liveliness. The function succeeds without doing anything. |
-| `rmw_node_assert_liveliness` | **Node liveliness** | Same as above. |
-| `rmw_publisher_wait_for_all_acked` | **Wait for acknowledgment** | Unix domain sockets deliver immediately on localhost — there's nothing to wait for. Returns success instantly. |
-| `rmw_set_log_severity` | **RMW log level** | We don't have internal logging. The severity is accepted but has no effect. |
-
-### QoS policies: what's enforced and what's not
-
-| QoS Policy | Status | Detail |
-|---|---|---|
-| `history` = KEEP_LAST | **Enforced** | Subscription message queue depth is capped at QoS `depth`. Oldest messages are dropped when the queue is full. |
-| `history` = KEEP_ALL | **Not enforced** | Treated as KEEP_LAST with depth=10. Unbounded queues are not supported. |
-| `depth` | **Enforced** | Controls both subscription queue size and TRANSIENT_LOCAL publisher cache size. |
-| `durability` = VOLATILE | **Enforced** | Publisher doesn't cache. Late-joining subscribers miss past messages. |
-| `durability` = TRANSIENT_LOCAL | **Enforced** | Publisher caches last `depth` messages. Late-joining subscribers receive the cache on first publish after they join. |
-| `reliability` = RELIABLE | **Accepted, not differentiated** | Unix sockets are inherently reliable on localhost. No messages are dropped in transit. |
-| `reliability` = BEST_EFFORT | **Accepted, not differentiated** | Behaves identically to RELIABLE because Unix sockets don't lose messages locally. |
-| `deadline` | **Not enforced** | Accepted but ignored. Would require a timer thread to monitor message delivery intervals. |
-| `lifespan` | **Not enforced** | Accepted but ignored. Would require timestamped expiration checks on every message. |
-| `liveliness` | **Not enforced** | Accepted but ignored. Would require periodic heartbeat checking. |
-| `liveliness_lease_duration` | **Not enforced** | Accepted but ignored. |
-
-### QoS compatibility checking (`rmw_qos_profile_check_compatible`)
-
-The following combinations are flagged as `RMW_QOS_COMPATIBILITY_WARNING`:
-
-| Publisher | Subscriber | Result | Reason |
-|---|---|---|---|
-| BEST_EFFORT | RELIABLE | Warning | Subscriber expects reliable delivery but publisher offers best-effort. On this RMW they behave identically, but it indicates a likely intent mismatch. |
-| VOLATILE | TRANSIENT_LOCAL | Warning | Subscriber expects late-joining replay but publisher doesn't cache. The subscriber will never receive past messages. |
-
-All other combinations return `RMW_QOS_COMPATIBILITY_OK`.
+| `rmw_init_publisher_allocation` / `rmw_fini_publisher_allocation` | **Pre-allocated publishing** | Our serialization allocates dynamically per-publish (via `fastcdr`). Hints are accepted but ignored. |
+| `rmw_init_subscription_allocation` / `rmw_fini_subscription_allocation` | **Pre-allocated taking** | Same — hints accepted but ignored. |
+| `rmw_publisher_assert_liveliness`, `rmw_node_assert_liveliness` | **Manual liveliness assertion** | We don't track liveliness. |
+| `rmw_publisher_wait_for_all_acked` | **Wait for acknowledgment** | Unix domain sockets deliver immediately on localhost — nothing to wait for. |
+| `rmw_set_log_severity` | **RMW log level** | We use `rcutils` logging; severity is accepted but has no effect on our own logs. |

--- a/rmw_unix_socket_cpp/package.xml
+++ b/rmw_unix_socket_cpp/package.xml
@@ -7,7 +7,7 @@
     Lightweight RMW implementation for ROS 2 using Unix domain sockets.
     Designed for localhost-only communication with minimal resource usage.
   </description>
-  <maintainer email="user@example.com">user</maintainer>
+  <maintainer email="benaliabderrahmen88@gmail.com">Abderahmane BENALI</maintainer>
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/rmw_unix_socket_cpp/src/identifier.hpp
+++ b/rmw_unix_socket_cpp/src/identifier.hpp
@@ -1,3 +1,17 @@
+// Copyright 2026 Abderahmane BENALI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef RMW_UNIX_SOCKET_CPP__IDENTIFIER_HPP_
 #define RMW_UNIX_SOCKET_CPP__IDENTIFIER_HPP_
 
@@ -7,7 +21,7 @@ namespace rmw_uds
 // address across all translation units.  The RMW framework compares
 // implementation_identifier by pointer, not by string value.
 inline constexpr char identifier[] = "rmw_unix_socket_cpp";
-inline constexpr char serialization_format[] = "uds_introspection";
+inline constexpr char serialization_format[] = "cdr";
 }  // namespace rmw_uds
 
 #endif  // RMW_UNIX_SOCKET_CPP__IDENTIFIER_HPP_

--- a/rmw_unix_socket_cpp/src/logging.hpp
+++ b/rmw_unix_socket_cpp/src/logging.hpp
@@ -1,3 +1,17 @@
+// Copyright 2026 Abderahmane BENALI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef RMW_UNIX_SOCKET_CPP__LOGGING_HPP_
 #define RMW_UNIX_SOCKET_CPP__LOGGING_HPP_
 

--- a/rmw_unix_socket_cpp/src/registry.cpp
+++ b/rmw_unix_socket_cpp/src/registry.cpp
@@ -1,3 +1,17 @@
+// Copyright 2026 Abderahmane BENALI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "registry.hpp"
 
 #include <cerrno>

--- a/rmw_unix_socket_cpp/src/registry.hpp
+++ b/rmw_unix_socket_cpp/src/registry.hpp
@@ -1,3 +1,17 @@
+// Copyright 2026 Abderahmane BENALI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef RMW_UNIX_SOCKET_CPP__REGISTRY_HPP_
 #define RMW_UNIX_SOCKET_CPP__REGISTRY_HPP_
 

--- a/rmw_unix_socket_cpp/src/rmw_client.cpp
+++ b/rmw_unix_socket_cpp/src/rmw_client.cpp
@@ -1,3 +1,17 @@
+// Copyright 2026 Abderahmane BENALI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "identifier.hpp"
 #include "logging.hpp"
 #include "registry.hpp"

--- a/rmw_unix_socket_cpp/src/rmw_event.cpp
+++ b/rmw_unix_socket_cpp/src/rmw_event.cpp
@@ -1,3 +1,17 @@
+// Copyright 2026 Abderahmane BENALI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "identifier.hpp"
 #include "types.hpp"
 

--- a/rmw_unix_socket_cpp/src/rmw_features.cpp
+++ b/rmw_unix_socket_cpp/src/rmw_features.cpp
@@ -1,3 +1,17 @@
+// Copyright 2026 Abderahmane BENALI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "identifier.hpp"
 
 #include <cstdio>

--- a/rmw_unix_socket_cpp/src/rmw_graph.cpp
+++ b/rmw_unix_socket_cpp/src/rmw_graph.cpp
@@ -1,3 +1,17 @@
+// Copyright 2026 Abderahmane BENALI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "identifier.hpp"
 #include "registry.hpp"
 #include "types.hpp"

--- a/rmw_unix_socket_cpp/src/rmw_guard_condition.cpp
+++ b/rmw_unix_socket_cpp/src/rmw_guard_condition.cpp
@@ -1,3 +1,17 @@
+// Copyright 2026 Abderahmane BENALI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "identifier.hpp"
 #include "types.hpp"
 

--- a/rmw_unix_socket_cpp/src/rmw_init.cpp
+++ b/rmw_unix_socket_cpp/src/rmw_init.cpp
@@ -1,3 +1,17 @@
+// Copyright 2026 Abderahmane BENALI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <sys/stat.h>
 
 #include "identifier.hpp"

--- a/rmw_unix_socket_cpp/src/rmw_node.cpp
+++ b/rmw_unix_socket_cpp/src/rmw_node.cpp
@@ -1,3 +1,17 @@
+// Copyright 2026 Abderahmane BENALI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "identifier.hpp"
 #include "registry.hpp"
 #include "types.hpp"

--- a/rmw_unix_socket_cpp/src/rmw_publisher.cpp
+++ b/rmw_unix_socket_cpp/src/rmw_publisher.cpp
@@ -1,3 +1,17 @@
+// Copyright 2026 Abderahmane BENALI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "identifier.hpp"
 #include "logging.hpp"
 #include "registry.hpp"

--- a/rmw_unix_socket_cpp/src/rmw_serialize.cpp
+++ b/rmw_unix_socket_cpp/src/rmw_serialize.cpp
@@ -1,3 +1,17 @@
+// Copyright 2026 Abderahmane BENALI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "serialization.hpp"
 
 #include <cstring>

--- a/rmw_unix_socket_cpp/src/rmw_service.cpp
+++ b/rmw_unix_socket_cpp/src/rmw_service.cpp
@@ -1,3 +1,17 @@
+// Copyright 2026 Abderahmane BENALI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "identifier.hpp"
 #include "logging.hpp"
 #include "registry.hpp"

--- a/rmw_unix_socket_cpp/src/rmw_subscription.cpp
+++ b/rmw_unix_socket_cpp/src/rmw_subscription.cpp
@@ -1,3 +1,17 @@
+// Copyright 2026 Abderahmane BENALI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "identifier.hpp"
 #include "logging.hpp"
 #include "registry.hpp"

--- a/rmw_unix_socket_cpp/src/rmw_unsupported.cpp
+++ b/rmw_unix_socket_cpp/src/rmw_unsupported.cpp
@@ -1,3 +1,17 @@
+// Copyright 2026 Abderahmane BENALI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "identifier.hpp"
 
 #include <cstring>

--- a/rmw_unix_socket_cpp/src/rmw_wait.cpp
+++ b/rmw_unix_socket_cpp/src/rmw_wait.cpp
@@ -1,3 +1,17 @@
+// Copyright 2026 Abderahmane BENALI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "identifier.hpp"
 #include "registry.hpp"
 #include "transport.hpp"

--- a/rmw_unix_socket_cpp/src/serialization.cpp
+++ b/rmw_unix_socket_cpp/src/serialization.cpp
@@ -1,3 +1,17 @@
+// Copyright 2026 Abderahmane BENALI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Serialization using fastcdr + rosidl_typesupport_fastrtps generated callbacks.
 // This approach uses compiled per-message-type serialization code, avoiding
 // runtime introspection walking which is fragile with C/C++ ABI differences.

--- a/rmw_unix_socket_cpp/src/serialization.hpp
+++ b/rmw_unix_socket_cpp/src/serialization.hpp
@@ -1,3 +1,17 @@
+// Copyright 2026 Abderahmane BENALI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef RMW_UNIX_SOCKET_CPP__SERIALIZATION_HPP_
 #define RMW_UNIX_SOCKET_CPP__SERIALIZATION_HPP_
 

--- a/rmw_unix_socket_cpp/src/transport.cpp
+++ b/rmw_unix_socket_cpp/src/transport.cpp
@@ -1,3 +1,17 @@
+// Copyright 2026 Abderahmane BENALI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "transport.hpp"
 
 #include <cerrno>

--- a/rmw_unix_socket_cpp/src/transport.hpp
+++ b/rmw_unix_socket_cpp/src/transport.hpp
@@ -1,3 +1,17 @@
+// Copyright 2026 Abderahmane BENALI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef RMW_UNIX_SOCKET_CPP__TRANSPORT_HPP_
 #define RMW_UNIX_SOCKET_CPP__TRANSPORT_HPP_
 

--- a/rmw_unix_socket_cpp/src/types.hpp
+++ b/rmw_unix_socket_cpp/src/types.hpp
@@ -1,3 +1,17 @@
+// Copyright 2026 Abderahmane BENALI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef RMW_UNIX_SOCKET_CPP__TYPES_HPP_
 #define RMW_UNIX_SOCKET_CPP__TYPES_HPP_
 

--- a/rmw_unix_socket_cpp/test/README.md
+++ b/rmw_unix_socket_cpp/test/README.md
@@ -67,7 +67,7 @@ Tests context initialization and shutdown lifecycle.
 | Test | What it validates | Why it matters |
 |------|-------------------|----------------|
 | `GetIdentifier` | `rmw_get_implementation_identifier()` returns `"rmw_unix_socket_cpp"` | The identifier string is used by `RMW_CHECK_TYPE_IDENTIFIERS_MATCH` in every API call. Wrong identifier = every call rejected. |
-| `GetSerializationFormat` | `rmw_get_serialization_format()` returns `"uds_introspection"` | Used by rosbag2 and tools to identify the wire format. Must be non-null and stable. |
+| `GetSerializationFormat` | `rmw_get_serialization_format()` returns `"cdr"` | Used by rosbag2 and tools to identify the wire format. The payload is standard DDS-CDR (fastcdr), so bags are interoperable with other CDR RMWs. |
 | `InitOptionsLifecycle` | Init, copy, fini of `rmw_init_options_t` | Options carry domain_id, security, allocator. A leak in copy/fini would accumulate over process lifetime. |
 | `InitShutdownLifecycle` | `rmw_init` → `rmw_shutdown` → `rmw_context_fini` | Full lifecycle. Validates shared memory registry is opened, send socket is created, and everything is cleaned up. Leaked fds or shm would accumulate across init/fini cycles. |
 | `NullArgumentsRejected` | Null pointers return `RMW_RET_INVALID_ARGUMENT` | Prevents segfaults from user error. Every public API must validate inputs. |

--- a/rmw_unix_socket_cpp/test/perf/README.md
+++ b/rmw_unix_socket_cpp/test/perf/README.md
@@ -27,7 +27,7 @@ Build and source the workspace first:
 
 ```bash
 source /opt/ros/jazzy/setup.bash
-cd /home/abe/projects/drixo_ws_ros2/rmw
+cd /path/to/your/workspace
 colcon build --packages-select rmw_unix_socket_cpp
 source install/setup.bash
 ```

--- a/rmw_unix_socket_cpp/test/test_base.hpp
+++ b/rmw_unix_socket_cpp/test/test_base.hpp
@@ -1,3 +1,17 @@
+// Copyright 2026 Abderahmane BENALI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef RMW_UNIX_SOCKET_CPP__TEST_BASE_HPP_
 #define RMW_UNIX_SOCKET_CPP__TEST_BASE_HPP_
 

--- a/rmw_unix_socket_cpp/test/test_registry.cpp
+++ b/rmw_unix_socket_cpp/test/test_registry.cpp
@@ -1,3 +1,17 @@
+// Copyright 2026 Abderahmane BENALI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <gtest/gtest.h>
 
 #include <algorithm>

--- a/rmw_unix_socket_cpp/test/test_registry_concurrent.cpp
+++ b/rmw_unix_socket_cpp/test/test_registry_concurrent.cpp
@@ -1,3 +1,17 @@
+// Copyright 2026 Abderahmane BENALI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Concurrency stress tests for the lock-free registry.
 //
 // These tests verify that the per-slot seqlock + atomic-CAS protocol holds up

--- a/rmw_unix_socket_cpp/test/test_rmw_graph.cpp
+++ b/rmw_unix_socket_cpp/test/test_rmw_graph.cpp
@@ -1,3 +1,17 @@
+// Copyright 2026 Abderahmane BENALI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "test_base.hpp"
 
 #include <cstring>

--- a/rmw_unix_socket_cpp/test/test_rmw_guard_condition.cpp
+++ b/rmw_unix_socket_cpp/test/test_rmw_guard_condition.cpp
@@ -1,3 +1,17 @@
+// Copyright 2026 Abderahmane BENALI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "test_base.hpp"
 
 #include <sys/eventfd.h>

--- a/rmw_unix_socket_cpp/test/test_rmw_init.cpp
+++ b/rmw_unix_socket_cpp/test/test_rmw_init.cpp
@@ -1,3 +1,17 @@
+// Copyright 2026 Abderahmane BENALI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <gtest/gtest.h>
 
 #include "rmw/rmw.h"
@@ -15,7 +29,7 @@ TEST(RmwInitTest, GetSerializationFormat)
 {
   const char * fmt = rmw_get_serialization_format();
   ASSERT_NE(nullptr, fmt);
-  EXPECT_STREQ("uds_introspection", fmt);
+  EXPECT_STREQ("cdr", fmt);
 }
 
 TEST(RmwInitTest, InitOptionsLifecycle)

--- a/rmw_unix_socket_cpp/test/test_rmw_node.cpp
+++ b/rmw_unix_socket_cpp/test/test_rmw_node.cpp
@@ -1,3 +1,17 @@
+// Copyright 2026 Abderahmane BENALI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "test_base.hpp"
 
 TEST_F(RmwUdsTestBase, CreateDestroyNode)

--- a/rmw_unix_socket_cpp/test/test_rmw_pub_sub.cpp
+++ b/rmw_unix_socket_cpp/test/test_rmw_pub_sub.cpp
@@ -1,3 +1,17 @@
+// Copyright 2026 Abderahmane BENALI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "test_base.hpp"
 
 #include <cstring>

--- a/rmw_unix_socket_cpp/test/test_rmw_qos.cpp
+++ b/rmw_unix_socket_cpp/test/test_rmw_qos.cpp
@@ -1,3 +1,17 @@
+// Copyright 2026 Abderahmane BENALI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "test_base.hpp"
 
 #include <cstdlib>

--- a/rmw_unix_socket_cpp/test/test_rmw_service_client.cpp
+++ b/rmw_unix_socket_cpp/test/test_rmw_service_client.cpp
@@ -1,3 +1,17 @@
+// Copyright 2026 Abderahmane BENALI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "test_base.hpp"
 
 #include <cstring>

--- a/rmw_unix_socket_cpp/test/test_rmw_wait.cpp
+++ b/rmw_unix_socket_cpp/test/test_rmw_wait.cpp
@@ -1,3 +1,17 @@
+// Copyright 2026 Abderahmane BENALI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "test_base.hpp"
 
 #include <cstring>

--- a/rmw_unix_socket_cpp/test/test_serialization.cpp
+++ b/rmw_unix_socket_cpp/test/test_serialization.cpp
@@ -1,3 +1,17 @@
+// Copyright 2026 Abderahmane BENALI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <gtest/gtest.h>
 
 #include <cstring>

--- a/rmw_unix_socket_cpp/test/test_transport.cpp
+++ b/rmw_unix_socket_cpp/test/test_transport.cpp
@@ -1,3 +1,17 @@
+// Copyright 2026 Abderahmane BENALI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <gtest/gtest.h>
 
 #include <cstdio>


### PR DESCRIPTION
Publish-readiness prep (license, headers, metadata, honest serialization format) ahead of making the repo public.

## Changes
- **LICENSE**: add the full Apache-2.0 text at repo root (was declared in package.xml/README but the file was missing).
- **License headers**: add the Apache-2.0 header to all 35 `.cpp`/`.hpp` source + test files (copyright: Abderahmane BENALI).
- **package.xml**: replace the `user@example.com` placeholder maintainer with a real one.
- **Serialization format**: `rmw_get_serialization_format()` now returns `"cdr"` instead of `"uds_introspection"`. The wire payload is already standard DDS-CDR (fastcdr `DDS_CDR` + `serialize_encapsulation()`), so this makes rosbag2 recordings interoperable with other CDR RMWs. Updated the `GetSerializationFormat` test and its test/README row to match.
- **DESIGN.md**: revise/expand; remove internal deployment references.

## Verification
Static checks done locally (headers placed correctly above include guards / leading comments; no remaining refs to the old format string; no internal names in the committed tree). Functional verification deferred to this PR's CI (build + full gtest suite on jazzy/kilted/rolling) — the only functional change is the format string + its test.

## Not in this PR (flagged for follow-up)
- `test/perf/README.md` still contains a personal path (`/home/abe/...`) — pre-existing on main, out of the "DESIGN.md" scope of this change.
- package.xml `version` is still `0.1.0` (unchanged; it has historically lagged the tags).