### PR TITLE
fix(timestamps): stamp message info with the wall clock, not the monotonic clock

### DIFF
--- a/rmw_unix_socket_cpp/src/rmw_client.cpp
+++ b/rmw_unix_socket_cpp/src/rmw_client.cpp
@@ -48,10 +48,12 @@ static rmw_qos_profile_t resolve_qos(const rmw_qos_profile_t * qos)
   return resolved;
 }
 
-static int64_t now_ns()
+// Wall clock: rmw_service_info_t timestamps are ns since the Unix epoch, same
+// as the message-info timestamps on the topic path.
+static int64_t wall_now_ns()
 {
   return std::chrono::duration_cast<std::chrono::nanoseconds>(
-    std::chrono::steady_clock::now().time_since_epoch()).count();
+    std::chrono::system_clock::now().time_since_epoch()).count();
 }
 
 extern "C"
@@ -192,7 +194,7 @@ rmw_ret_t rmw_send_request(
   std::memset(&hdr, 0, sizeof(hdr));
   std::memcpy(hdr.gid, cli_data->gid.data, sizeof(hdr.gid));
   hdr.sequence_number = *sequence_id;
-  hdr.source_timestamp_ns = now_ns();
+  hdr.source_timestamp_ns = wall_now_ns();
   hdr.msg_type = 1;  // request
 
   // Serialize the request, choosing its destination by size: a large one is
@@ -273,7 +275,7 @@ rmw_ret_t rmw_take_response(
     rmw_uds::ReceivedMessage msg;
     msg.header = hdr;
     msg.payload = std::move(payload);
-    msg.received_timestamp_ns = now_ns();
+    msg.received_timestamp_ns = wall_now_ns();
     std::lock_guard<std::mutex> lock(cli_data->queue_mutex);
     cli_data->response_queue.push_back(std::move(msg));
     payload.clear();

--- a/rmw_unix_socket_cpp/src/rmw_publisher.cpp
+++ b/rmw_unix_socket_cpp/src/rmw_publisher.cpp
@@ -51,9 +51,11 @@ static rmw_qos_profile_t resolve_qos(const rmw_qos_profile_t * qos)
   return resolved;
 }
 
-static int64_t now_ns()
+// Wall clock: the wire header's source_timestamp_ns is ns since the Unix epoch
+// (it surfaces as rmw_message_info_t::source_timestamp on the take side).
+static int64_t wall_now_ns()
 {
-  auto now = std::chrono::steady_clock::now();
+  auto now = std::chrono::system_clock::now();
   return std::chrono::duration_cast<std::chrono::nanoseconds>(
     now.time_since_epoch()).count();
 }
@@ -305,7 +307,7 @@ rmw_ret_t rmw_publish(
   std::memset(&hdr, 0, sizeof(hdr));
   std::memcpy(hdr.gid, pub_data->gid.data, sizeof(hdr.gid));
   hdr.sequence_number = pub_data->sequence_number.fetch_add(1, std::memory_order_relaxed);
-  hdr.source_timestamp_ns = now_ns();
+  hdr.source_timestamp_ns = wall_now_ns();
   hdr.msg_type = 0;  // topic message
 
   // PERFORMANCE: only lock the registry when the graph generation has changed
@@ -430,7 +432,7 @@ rmw_ret_t rmw_publish_serialized_message(
   std::memset(&hdr, 0, sizeof(hdr));
   std::memcpy(hdr.gid, pub_data->gid.data, sizeof(hdr.gid));
   hdr.sequence_number = pub_data->sequence_number.fetch_add(1, std::memory_order_relaxed);
-  hdr.source_timestamp_ns = now_ns();
+  hdr.source_timestamp_ns = wall_now_ns();
   hdr.payload_size = static_cast<uint32_t>(serialized_message->buffer_length);
   hdr.msg_type = 0;
 

--- a/rmw_unix_socket_cpp/src/rmw_service.cpp
+++ b/rmw_unix_socket_cpp/src/rmw_service.cpp
@@ -48,10 +48,12 @@ static rmw_qos_profile_t resolve_qos(const rmw_qos_profile_t * qos)
   return resolved;
 }
 
-static int64_t now_ns()
+// Wall clock: rmw_service_info_t timestamps are ns since the Unix epoch, same
+// as the message-info timestamps on the topic path.
+static int64_t wall_now_ns()
 {
   return std::chrono::duration_cast<std::chrono::nanoseconds>(
-    std::chrono::steady_clock::now().time_since_epoch()).count();
+    std::chrono::system_clock::now().time_since_epoch()).count();
 }
 
 extern "C"
@@ -202,7 +204,7 @@ rmw_ret_t rmw_take_request(
     rmw_uds::ReceivedMessage msg;
     msg.header = hdr;
     msg.payload = std::move(payload);
-    msg.received_timestamp_ns = now_ns();
+    msg.received_timestamp_ns = wall_now_ns();
     std::lock_guard<std::mutex> lock(srv_data->queue_mutex);
     srv_data->request_queue.push_back(std::move(msg));
     payload.clear();
@@ -260,7 +262,7 @@ rmw_ret_t rmw_send_response(
   std::memset(&hdr, 0, sizeof(hdr));
   std::memcpy(hdr.gid, request_header->writer_guid, sizeof(hdr.gid));
   hdr.sequence_number = request_header->sequence_number;
-  hdr.source_timestamp_ns = now_ns();
+  hdr.source_timestamp_ns = wall_now_ns();
   hdr.msg_type = 2;  // response
 
   // Serialize the response, choosing its destination by size: a large one is

--- a/rmw_unix_socket_cpp/src/rmw_subscription.cpp
+++ b/rmw_unix_socket_cpp/src/rmw_subscription.cpp
@@ -50,10 +50,12 @@ static rmw_qos_profile_t resolve_qos(const rmw_qos_profile_t * qos)
   return resolved;
 }
 
-static int64_t now_ns()
+// Wall clock: rmw_message_info_t timestamps are ns since the Unix epoch
+// (rosbag2 writes them into the bag verbatim), so a monotonic clock won't do.
+static int64_t wall_now_ns()
 {
   return std::chrono::duration_cast<std::chrono::nanoseconds>(
-    std::chrono::steady_clock::now().time_since_epoch()).count();
+    std::chrono::system_clock::now().time_since_epoch()).count();
 }
 
 // Drain socket into message queue
@@ -74,7 +76,7 @@ static void drain_subscription(rmw_uds::UdsSubscription * sub)
     rmw_uds::ReceivedMessage msg;
     msg.header = hdr;
     msg.payload = std::move(payload);
-    msg.received_timestamp_ns = now_ns();
+    msg.received_timestamp_ns = wall_now_ns();
 
     bool overflow = false;
     {

--- a/rmw_unix_socket_cpp/src/rmw_wait.cpp
+++ b/rmw_unix_socket_cpp/src/rmw_wait.cpp
@@ -34,10 +34,19 @@
 #include "rmw/error_handling.h"
 #include "rmw/rmw.h"
 
+// Monotonic — for wait deadlines only.
 static int64_t now_ns()
 {
   return std::chrono::duration_cast<std::chrono::nanoseconds>(
     std::chrono::steady_clock::now().time_since_epoch()).count();
+}
+
+// Wall clock: received_timestamp_ns is ns since the Unix epoch, so the drain
+// below must not stamp it with the monotonic clock above.
+static int64_t wall_now_ns()
+{
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(
+    std::chrono::system_clock::now().time_since_epoch()).count();
 }
 
 // Drain a socket into a message queue (subscription, service, or client).
@@ -69,7 +78,7 @@ static void drain_socket(
     rmw_uds::ReceivedMessage msg;
     msg.header = hdr;
     msg.payload = std::move(payload);
-    msg.received_timestamp_ns = now_ns();
+    msg.received_timestamp_ns = wall_now_ns();
 
     {
       std::lock_guard<std::mutex> lock(queue_mutex);

--- a/rmw_unix_socket_cpp/test/test_base.hpp
+++ b/rmw_unix_socket_cpp/test/test_base.hpp
@@ -17,6 +17,9 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
+#include <cstdint>
+
 #include "rmw/rmw.h"
 #include "rmw/init.h"
 #include "rmw/init_options.h"
@@ -24,6 +27,14 @@
 // Use the identifier from the shared library, not our own copy.
 // Pointer comparison requires the same address.
 inline const char * uds_id() { return rmw_get_implementation_identifier(); }
+
+// Wall clock reference for message-info timestamp checks: rmw_message_info_t
+// timestamps are ns since the Unix epoch.
+inline int64_t wall_now_ns()
+{
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(
+    std::chrono::system_clock::now().time_since_epoch()).count();
+}
 
 // Base fixture: provides a valid rmw_context_t for tests.
 class RmwUdsTestBase : public ::testing::Test

--- a/rmw_unix_socket_cpp/test/test_rmw_pub_sub.cpp
+++ b/rmw_unix_socket_cpp/test/test_rmw_pub_sub.cpp
@@ -131,6 +131,38 @@ TEST_F(PubSubTest, TakeWithInfo)
   EXPECT_GE(info.publication_sequence_number, 1u);
 }
 
+TEST_F(PubSubTest, TakeWithInfoTimestampsAreUnixEpoch)
+{
+  // rosbag2 (Jazzy) writes rmw_message_info timestamps into the bag verbatim,
+  // so they must be ns since the Unix epoch. A monotonic reading is a small
+  // number of ns and shows up as 1970 in the bag.
+  auto pub_opts = rmw_get_default_publisher_options();
+  pub = rmw_create_publisher(node, ts, "/epoch_topic", &qos, &pub_opts);
+  auto sub_opts = rmw_get_default_subscription_options();
+  sub = rmw_create_subscription(node, ts, "/epoch_topic", &qos, &sub_opts);
+  ASSERT_NE(nullptr, pub);
+  ASSERT_NE(nullptr, sub);
+
+  const int64_t before = wall_now_ns();
+
+  test_msgs::msg::BasicTypes send_msg;
+  send_msg.int32_value = 7;
+  EXPECT_EQ(RMW_RET_OK, rmw_publish(pub, &send_msg, nullptr));
+
+  test_msgs::msg::BasicTypes recv_msg;
+  bool taken = false;
+  rmw_message_info_t info = rmw_get_zero_initialized_message_info();
+  EXPECT_EQ(RMW_RET_OK, rmw_take_with_info(sub, &recv_msg, &taken, &info, nullptr));
+  ASSERT_TRUE(taken);
+
+  const int64_t after = wall_now_ns();
+
+  EXPECT_GE(info.source_timestamp, before);
+  EXPECT_LE(info.source_timestamp, after);
+  EXPECT_GE(info.received_timestamp, before);
+  EXPECT_LE(info.received_timestamp, after);
+}
+
 TEST_F(PubSubTest, TakeEmptyReturnsFalse)
 {
   auto sub_opts = rmw_get_default_subscription_options();

--- a/rmw_unix_socket_cpp/test/test_rmw_service_client.cpp
+++ b/rmw_unix_socket_cpp/test/test_rmw_service_client.cpp
@@ -136,6 +136,52 @@ TEST_F(ServiceClientTest, RequestResponseRoundTrip)
   EXPECT_EQ("success", recv_response.string_value);
 }
 
+TEST_F(ServiceClientTest, RequestResponseTimestampsAreUnixEpoch)
+{
+  // rmw_service_info_t carries the same epoch-based timestamps as
+  // rmw_message_info_t (service introspection records them).
+  srv = rmw_create_service(node, ts, "/epoch_srv", &qos);
+  cli = rmw_create_client(node, ts, "/epoch_srv", &qos);
+  ASSERT_NE(nullptr, srv);
+  ASSERT_NE(nullptr, cli);
+
+  const int64_t before = wall_now_ns();
+
+  test_msgs::srv::BasicTypes::Request request;
+  request.int32_value = 42;
+  int64_t seq_id = 0;
+  EXPECT_EQ(RMW_RET_OK, rmw_send_request(cli, &request, &seq_id));
+
+  test_msgs::srv::BasicTypes::Request recv_request;
+  rmw_service_info_t request_header;
+  std::memset(&request_header, 0, sizeof(request_header));
+  bool taken = false;
+  EXPECT_EQ(RMW_RET_OK, rmw_take_request(srv, &request_header, &recv_request, &taken));
+  ASSERT_TRUE(taken);
+
+  test_msgs::srv::BasicTypes::Response response;
+  response.int32_value = 84;
+  EXPECT_EQ(RMW_RET_OK, rmw_send_response(srv, &request_header.request_id, &response));
+
+  test_msgs::srv::BasicTypes::Response recv_response;
+  rmw_service_info_t response_header;
+  std::memset(&response_header, 0, sizeof(response_header));
+  taken = false;
+  EXPECT_EQ(RMW_RET_OK, rmw_take_response(cli, &response_header, &recv_response, &taken));
+  ASSERT_TRUE(taken);
+
+  const int64_t after = wall_now_ns();
+
+  EXPECT_GE(request_header.source_timestamp, before);
+  EXPECT_LE(request_header.source_timestamp, after);
+  EXPECT_GE(request_header.received_timestamp, before);
+  EXPECT_LE(request_header.received_timestamp, after);
+  EXPECT_GE(response_header.source_timestamp, before);
+  EXPECT_LE(response_header.source_timestamp, after);
+  EXPECT_GE(response_header.received_timestamp, before);
+  EXPECT_LE(response_header.received_timestamp, after);
+}
+
 TEST_F(ServiceClientTest, LargeRequestAndResponseViaShm)
 {
   // A >4 MB request and a >4 MB response must round-trip. Both exceed the

--- a/rmw_unix_socket_cpp/test/test_rmw_wait.cpp
+++ b/rmw_unix_socket_cpp/test/test_rmw_wait.cpp
@@ -87,6 +87,67 @@ TEST_F(RmwUdsNodeTest, WaitTimeoutWhenNoData)
   EXPECT_EQ(RMW_RET_OK, rmw_destroy_guard_condition(gc));
 }
 
+TEST_F(RmwUdsNodeTest, WaitDrainStampsReceivedTimestampWithWallClock)
+{
+  // The executor path drains sockets inside rmw_wait, so that drain stamps
+  // received_timestamp — it must be ns since the Unix epoch, same as the
+  // take-side drain.
+  auto * ts = rosidl_typesupport_cpp::get_message_type_support_handle<
+    test_msgs::msg::BasicTypes>();
+
+  rmw_qos_profile_t qos;
+  std::memset(&qos, 0, sizeof(qos));
+  qos.history = RMW_QOS_POLICY_HISTORY_KEEP_LAST;
+  qos.depth = 10;
+  qos.reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+  qos.durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+
+  auto pub_opts = rmw_get_default_publisher_options();
+  auto * pub = rmw_create_publisher(node, ts, "/wait_epoch", &qos, &pub_opts);
+  auto sub_opts = rmw_get_default_subscription_options();
+  auto * sub = rmw_create_subscription(node, ts, "/wait_epoch", &qos, &sub_opts);
+  ASSERT_NE(nullptr, pub);
+  ASSERT_NE(nullptr, sub);
+
+  auto * ws = rmw_create_wait_set(&context, 1);
+  ASSERT_NE(nullptr, ws);
+
+  const int64_t before = wall_now_ns();
+
+  test_msgs::msg::BasicTypes msg;
+  msg.int32_value = 77;
+  EXPECT_EQ(RMW_RET_OK, rmw_publish(pub, &msg, nullptr));
+
+  rmw_subscriptions_t subscriptions;
+  void * sub_array[1] = {sub->data};
+  subscriptions.subscribers = sub_array;
+  subscriptions.subscriber_count = 1;
+
+  rmw_time_t timeout;
+  timeout.sec = 1;
+  timeout.nsec = 0;
+  EXPECT_EQ(
+    RMW_RET_OK,
+    rmw_wait(&subscriptions, nullptr, nullptr, nullptr, nullptr, ws, &timeout));
+
+  test_msgs::msg::BasicTypes recv;
+  bool taken = false;
+  rmw_message_info_t info = rmw_get_zero_initialized_message_info();
+  EXPECT_EQ(RMW_RET_OK, rmw_take_with_info(sub, &recv, &taken, &info, nullptr));
+  ASSERT_TRUE(taken);
+
+  const int64_t after = wall_now_ns();
+
+  EXPECT_GE(info.source_timestamp, before);
+  EXPECT_LE(info.source_timestamp, after);
+  EXPECT_GE(info.received_timestamp, before);
+  EXPECT_LE(info.received_timestamp, after);
+
+  EXPECT_EQ(RMW_RET_OK, rmw_destroy_wait_set(ws));
+  EXPECT_EQ(RMW_RET_OK, rmw_destroy_subscription(node, sub));
+  EXPECT_EQ(RMW_RET_OK, rmw_destroy_publisher(node, pub));
+}
+
 TEST_F(RmwUdsNodeTest, WaitWithSubscription)
 {
   auto * ts = rosidl_typesupport_cpp::get_message_type_support_handle<


### PR DESCRIPTION
## Problem

Bags recorded with this RMW under Jazzy show every message at **1 January 1970**.

In Jazzy, rosbag2 stopped stamping messages with the recorder node's own clock and writes the send/receive timestamps as reported by the middleware ([ros2/rosbag2#1531](https://github.com/ros2/rosbag2/pull/1531)) — i.e. `rmw_message_info_t::received_timestamp` / `source_timestamp` go into the bag verbatim.

Those fields are defined as **nanoseconds since the Unix epoch**, but every stamp in this RMW came from `std::chrono::steady_clock` (`CLOCK_MONOTONIC` — ns since boot). A recorder started 22 minutes after boot therefore wrote `1312664618690` ns ⇒ `1970-01-01T00:21:52Z`.

`rmw_cyclonedds` uses the wall clock for both fields (`dds_time()` → `CLOCK_REALTIME` for `source_timestamp`, `std::chrono::system_clock` for `received_timestamp`), which is why bags recorded over Cyclone are fine.

## Fix

Stamp message-visible timestamps with `system_clock`:

| Path | Stamp |
|---|---|
| `rmw_publish`, `rmw_publish_serialized_message` | `source_timestamp_ns` |
| `rmw_subscription` drain | `received_timestamp_ns` |
| `rmw_wait` drain (the executor/rosbag2 path) | `received_timestamp_ns` |
| `rmw_send_request` / `rmw_take_request`, `rmw_send_response` / `rmw_take_response` | both |

`rmw_wait` keeps `steady_clock` for its poll deadlines — those must stay monotonic, so it now has both helpers. The remaining `steady_clock` uses (socket/shm name uniquifiers) are unrelated to message timestamps and untouched.

Wire layout is unchanged: `WireHeader::source_timestamp_ns` is still an `int64_t` at offset 24, so the existing `static_assert` and cross-process compatibility hold. TRANSIENT_LOCAL late-joiner replay re-sends the cached original header, so replayed samples keep their true publish time.

## Tests

Three new tests, each written to fail first and bracketing the timestamps between two wall-clock reads:

- `PubSubTest.TakeWithInfoTimestampsAreUnixEpoch`
- `RmwUdsNodeTest.WaitDrainStampsReceivedTimestampWithWallClock` (covers the `rmw_wait` drain, which is the path rosbag2 actually takes)
- `ServiceClientTest.RequestResponseTimestampsAreUnixEpoch`

Before the fix all three failed with e.g. `actual: 1312664618690 vs 1785743133835997198`. After: full suite green — **127 tests, 0 failures**.

## Notes

The wall clock can step (NTP), so `source_timestamp` may occasionally exceed `received_timestamp` or bag stamps may be non-monotonic. That is inherent to the epoch-based contract and matches Cyclone/Fast DDS; no timeout or ordering logic in this RMW reads these fields, so nothing can hang on a backwards step.
