### PR TITLE
Use system clock to fill msgs timestamps

### DIFF
--- a/rmw_unix_socket_cpp/src/rmw_client.cpp
+++ b/rmw_unix_socket_cpp/src/rmw_client.cpp
@@ -51,7 +51,7 @@ static rmw_qos_profile_t resolve_qos(const rmw_qos_profile_t * qos)
 static int64_t now_ns()
 {
   return std::chrono::duration_cast<std::chrono::nanoseconds>(
-    std::chrono::steady_clock::now().time_since_epoch()).count();
+    std::chrono::system_clock::now().time_since_epoch()).count();
 }
 
 extern "C"

--- a/rmw_unix_socket_cpp/src/rmw_client.cpp
+++ b/rmw_unix_socket_cpp/src/rmw_client.cpp
@@ -48,7 +48,7 @@ static rmw_qos_profile_t resolve_qos(const rmw_qos_profile_t * qos)
   return resolved;
 }
 
-static int64_t now_ns()
+static int64_t system_now_ns()
 {
   return std::chrono::duration_cast<std::chrono::nanoseconds>(
     std::chrono::system_clock::now().time_since_epoch()).count();
@@ -192,7 +192,7 @@ rmw_ret_t rmw_send_request(
   std::memset(&hdr, 0, sizeof(hdr));
   std::memcpy(hdr.gid, cli_data->gid.data, sizeof(hdr.gid));
   hdr.sequence_number = *sequence_id;
-  hdr.source_timestamp_ns = now_ns();
+  hdr.source_timestamp_ns = system_now_ns();
   hdr.msg_type = 1;  // request
 
   // Serialize the request, choosing its destination by size: a large one is
@@ -273,7 +273,7 @@ rmw_ret_t rmw_take_response(
     rmw_uds::ReceivedMessage msg;
     msg.header = hdr;
     msg.payload = std::move(payload);
-    msg.received_timestamp_ns = now_ns();
+    msg.received_timestamp_ns = system_now_ns();
     std::lock_guard<std::mutex> lock(cli_data->queue_mutex);
     cli_data->response_queue.push_back(std::move(msg));
     payload.clear();

--- a/rmw_unix_socket_cpp/src/rmw_publisher.cpp
+++ b/rmw_unix_socket_cpp/src/rmw_publisher.cpp
@@ -51,7 +51,7 @@ static rmw_qos_profile_t resolve_qos(const rmw_qos_profile_t * qos)
   return resolved;
 }
 
-static int64_t now_ns()
+static int64_t system_now_ns()
 {
   auto now = std::chrono::system_clock::now();
   return std::chrono::duration_cast<std::chrono::nanoseconds>(
@@ -305,7 +305,7 @@ rmw_ret_t rmw_publish(
   std::memset(&hdr, 0, sizeof(hdr));
   std::memcpy(hdr.gid, pub_data->gid.data, sizeof(hdr.gid));
   hdr.sequence_number = pub_data->sequence_number.fetch_add(1, std::memory_order_relaxed);
-  hdr.source_timestamp_ns = now_ns();
+  hdr.source_timestamp_ns = system_now_ns();
   hdr.msg_type = 0;  // topic message
 
   // PERFORMANCE: only lock the registry when the graph generation has changed
@@ -430,7 +430,7 @@ rmw_ret_t rmw_publish_serialized_message(
   std::memset(&hdr, 0, sizeof(hdr));
   std::memcpy(hdr.gid, pub_data->gid.data, sizeof(hdr.gid));
   hdr.sequence_number = pub_data->sequence_number.fetch_add(1, std::memory_order_relaxed);
-  hdr.source_timestamp_ns = now_ns();
+  hdr.source_timestamp_ns = system_now_ns();
   hdr.payload_size = static_cast<uint32_t>(serialized_message->buffer_length);
   hdr.msg_type = 0;
 

--- a/rmw_unix_socket_cpp/src/rmw_publisher.cpp
+++ b/rmw_unix_socket_cpp/src/rmw_publisher.cpp
@@ -53,7 +53,7 @@ static rmw_qos_profile_t resolve_qos(const rmw_qos_profile_t * qos)
 
 static int64_t now_ns()
 {
-  auto now = std::chrono::steady_clock::now();
+  auto now = std::chrono::system_clock::now();
   return std::chrono::duration_cast<std::chrono::nanoseconds>(
     now.time_since_epoch()).count();
 }

--- a/rmw_unix_socket_cpp/src/rmw_service.cpp
+++ b/rmw_unix_socket_cpp/src/rmw_service.cpp
@@ -48,7 +48,7 @@ static rmw_qos_profile_t resolve_qos(const rmw_qos_profile_t * qos)
   return resolved;
 }
 
-static int64_t now_ns()
+static int64_t system_now_ns()
 {
   return std::chrono::duration_cast<std::chrono::nanoseconds>(
     std::chrono::system_clock::now().time_since_epoch()).count();
@@ -202,7 +202,7 @@ rmw_ret_t rmw_take_request(
     rmw_uds::ReceivedMessage msg;
     msg.header = hdr;
     msg.payload = std::move(payload);
-    msg.received_timestamp_ns = now_ns();
+    msg.received_timestamp_ns = system_now_ns();
     std::lock_guard<std::mutex> lock(srv_data->queue_mutex);
     srv_data->request_queue.push_back(std::move(msg));
     payload.clear();
@@ -260,7 +260,7 @@ rmw_ret_t rmw_send_response(
   std::memset(&hdr, 0, sizeof(hdr));
   std::memcpy(hdr.gid, request_header->writer_guid, sizeof(hdr.gid));
   hdr.sequence_number = request_header->sequence_number;
-  hdr.source_timestamp_ns = now_ns();
+  hdr.source_timestamp_ns = system_now_ns();
   hdr.msg_type = 2;  // response
 
   // Serialize the response, choosing its destination by size: a large one is

--- a/rmw_unix_socket_cpp/src/rmw_service.cpp
+++ b/rmw_unix_socket_cpp/src/rmw_service.cpp
@@ -51,7 +51,7 @@ static rmw_qos_profile_t resolve_qos(const rmw_qos_profile_t * qos)
 static int64_t now_ns()
 {
   return std::chrono::duration_cast<std::chrono::nanoseconds>(
-    std::chrono::steady_clock::now().time_since_epoch()).count();
+    std::chrono::system_clock::now().time_since_epoch()).count();
 }
 
 extern "C"

--- a/rmw_unix_socket_cpp/src/rmw_subscription.cpp
+++ b/rmw_unix_socket_cpp/src/rmw_subscription.cpp
@@ -50,7 +50,7 @@ static rmw_qos_profile_t resolve_qos(const rmw_qos_profile_t * qos)
   return resolved;
 }
 
-static int64_t now_ns()
+static int64_t system_now_ns()
 {
   return std::chrono::duration_cast<std::chrono::nanoseconds>(
     std::chrono::system_clock::now().time_since_epoch()).count();
@@ -74,7 +74,7 @@ static void drain_subscription(rmw_uds::UdsSubscription * sub)
     rmw_uds::ReceivedMessage msg;
     msg.header = hdr;
     msg.payload = std::move(payload);
-    msg.received_timestamp_ns = now_ns();
+    msg.received_timestamp_ns = system_now_ns();
 
     bool overflow = false;
     {

--- a/rmw_unix_socket_cpp/src/rmw_subscription.cpp
+++ b/rmw_unix_socket_cpp/src/rmw_subscription.cpp
@@ -53,7 +53,7 @@ static rmw_qos_profile_t resolve_qos(const rmw_qos_profile_t * qos)
 static int64_t now_ns()
 {
   return std::chrono::duration_cast<std::chrono::nanoseconds>(
-    std::chrono::steady_clock::now().time_since_epoch()).count();
+    std::chrono::system_clock::now().time_since_epoch()).count();
 }
 
 // Drain socket into message queue

--- a/rmw_unix_socket_cpp/src/rmw_wait.cpp
+++ b/rmw_unix_socket_cpp/src/rmw_wait.cpp
@@ -34,10 +34,16 @@
 #include "rmw/error_handling.h"
 #include "rmw/rmw.h"
 
-static int64_t now_ns()
+static int64_t steady_now_ns()
 {
   return std::chrono::duration_cast<std::chrono::nanoseconds>(
     std::chrono::steady_clock::now().time_since_epoch()).count();
+}
+
+static int64_t wall_now_ns()
+{
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(
+    std::chrono::system_clock::now().time_since_epoch()).count();
 }
 
 // Drain a socket into a message queue (subscription, service, or client).
@@ -69,7 +75,7 @@ static void drain_socket(
     rmw_uds::ReceivedMessage msg;
     msg.header = hdr;
     msg.payload = std::move(payload);
-    msg.received_timestamp_ns = now_ns();
+    msg.received_timestamp_ns = wall_now_ns();
 
     {
       std::lock_guard<std::mutex> lock(queue_mutex);
@@ -399,7 +405,7 @@ rmw_ret_t rmw_wait(
     // so a signal interruption neither returns TIMEOUT early nor busy-loops.
     struct epoll_event ready_events[64];
     const int64_t deadline_ns =
-      (timeout_ms >= 0) ? now_ns() + static_cast<int64_t>(timeout_ms) * 1000000 : 0;
+      (timeout_ms >= 0) ? steady_now_ns() + static_cast<int64_t>(timeout_ms) * 1000000 : 0;
     int remaining_ms = timeout_ms;
     while (true) {
       int n = epoll_wait(ws_data->epoll_fd, ready_events, 64, remaining_ms);
@@ -413,7 +419,7 @@ rmw_ret_t rmw_wait(
       if (timeout_ms < 0) {
         continue;  // Infinite wait: just re-block.
       }
-      const int64_t rem_ns = deadline_ns - now_ns();
+      const int64_t rem_ns = deadline_ns - steady_now_ns();
       if (rem_ns <= 0) {
         break;  // Deadline passed -> timeout; fall through to drain.
       }


### PR DESCRIPTION
The steady_clock was used to set messages timestamps but this clock is based on CLOCK_MONOTICK, often the time since the boot.
We need to use the system clock to fill these timestamps which is based on CLOCK_REALTIME, the time since Unix epoch.

The steady clock needs to be kept to compute timeout deadlines in rmw_wait