### PR TITLE
perf(rmw_graph): throttle the stale-slot sweep off the graph query path

### DIFF
--- a/rmw_unix_socket_cpp/CMakeLists.txt
+++ b/rmw_unix_socket_cpp/CMakeLists.txt
@@ -199,8 +199,9 @@ if(BUILD_TESTING)
 
   # RMW API: graph introspection. registry.cpp is compiled in as well so the
   # test can seed the shared registry directly; the rmw library does not export
-  # those internal symbols. Both copies act on the same shared memory, and the
-  # registry keeps no per-process state, so this is safe.
+  # those internal symbols. Both copies act on the same shared memory; the only
+  # process-local state in registry.cpp is ring_doorbells' thread_local send-fd
+  # cache, one per copy, so the duplication is benign.
   ament_add_gtest(test_rmw_graph test/test_rmw_graph.cpp src/registry.cpp)
   target_link_libraries(test_rmw_graph ${_rmw_test_libs} ${_test_msg_deps})
   target_include_directories(test_rmw_graph PRIVATE src)

--- a/rmw_unix_socket_cpp/CMakeLists.txt
+++ b/rmw_unix_socket_cpp/CMakeLists.txt
@@ -197,8 +197,11 @@ if(BUILD_TESTING)
   target_link_libraries(test_rmw_wait ${_rmw_test_libs} ${_test_msg_deps})
   target_include_directories(test_rmw_wait PRIVATE src)
 
-  # RMW API: graph introspection
-  ament_add_gtest(test_rmw_graph test/test_rmw_graph.cpp)
+  # RMW API: graph introspection. registry.cpp is compiled in as well so the
+  # test can seed the shared registry directly; the rmw library does not export
+  # those internal symbols. Both copies act on the same shared memory, and the
+  # registry keeps no per-process state, so this is safe.
+  ament_add_gtest(test_rmw_graph test/test_rmw_graph.cpp src/registry.cpp)
   target_link_libraries(test_rmw_graph ${_rmw_test_libs} ${_test_msg_deps})
   target_include_directories(test_rmw_graph PRIVATE src)
 

--- a/rmw_unix_socket_cpp/src/rmw_graph.cpp
+++ b/rmw_unix_socket_cpp/src/rmw_graph.cpp
@@ -50,7 +50,7 @@ static int64_t steady_now_ns()
     std::chrono::steady_clock::now().time_since_epoch()).count();
 }
 
-// Shortest gap between two stale-slot sweeps in one process.
+// Shortest gap between two stale-slot sweeps in one context.
 static constexpr int64_t CLEANUP_MIN_INTERVAL_NS = 1000000000;  // 1 s
 
 // Reclaiming slots whose owner died is garbage collection: it walks every live
@@ -62,9 +62,12 @@ static constexpr int64_t CLEANUP_MIN_INTERVAL_NS = 1000000000;  // 1 s
 // This does not weaken any guarantee. A graph query can already return an
 // entity whose owner died a microsecond after the sweep that vetted it, so the
 // answer was never a liveness statement to begin with; the throttle only
-// widens a window that was always open. The full-registry path in registry_add
-// still sweeps unconditionally, because there it is the last resort before
-// entity creation fails.
+// widens a window that was always open. The observable cost is crash-detection
+// latency: reclaiming a dead process's slots — and with them the doorbell
+// rings and latched-cache teardown only a sweep produces — now lags up to one
+// interval per polling context. The full-registry path in registry_add still
+// sweeps unconditionally, because there it is the last resort before entity
+// creation fails.
 static void maybe_cleanup_stale(rmw_uds::UdsContext * ctx, rmw_uds::RegistryHeader * header)
 {
   const int64_t now = steady_now_ns();

--- a/rmw_unix_socket_cpp/src/rmw_graph.cpp
+++ b/rmw_unix_socket_cpp/src/rmw_graph.cpp
@@ -16,6 +16,7 @@
 #include "registry.hpp"
 #include "types.hpp"
 
+#include <chrono>
 #include <cstring>
 #include <map>
 #include <set>
@@ -43,6 +44,44 @@ static rmw_uds::UdsContext * get_context(const rmw_node_t * node)
   return nd->context;
 }
 
+static int64_t steady_now_ns()
+{
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(
+    std::chrono::steady_clock::now().time_since_epoch()).count();
+}
+
+// Shortest gap between two stale-slot sweeps in one process.
+static constexpr int64_t CLEANUP_MIN_INTERVAL_NS = 1000000000;  // 1 s
+
+// Reclaiming slots whose owner died is garbage collection: it walks every live
+// entry and stats /proc/<pid> for each one. Running that on every graph query
+// made a single call cost tens of milliseconds on a large registry, and a tool
+// polling the graph paid it several times a second whether or not anything had
+// changed. Sweep at most once per interval instead.
+//
+// This does not weaken any guarantee. A graph query can already return an
+// entity whose owner died a microsecond after the sweep that vetted it, so the
+// answer was never a liveness statement to begin with; the throttle only
+// widens a window that was always open. The full-registry path in registry_add
+// still sweeps unconditionally, because there it is the last resort before
+// entity creation fails.
+static void maybe_cleanup_stale(rmw_uds::UdsContext * ctx, rmw_uds::RegistryHeader * header)
+{
+  const int64_t now = steady_now_ns();
+  int64_t last = ctx->last_cleanup_ns.load(std::memory_order_relaxed);
+  if (now - last < CLEANUP_MIN_INTERVAL_NS) {
+    return;
+  }
+  // Whoever wins the CAS sweeps; the others skip rather than queue up behind
+  // it, which is the pile-up this change exists to remove.
+  if (!ctx->last_cleanup_ns.compare_exchange_strong(
+      last, now, std::memory_order_relaxed, std::memory_order_relaxed))
+  {
+    return;
+  }
+  rmw_uds::registry_cleanup_stale(header);
+}
+
 static std::vector<rmw_uds::RegistryQueryResult> query_all(
   rmw_uds::UdsContext * ctx,
   rmw_uds::RegistryEntryType type,
@@ -53,7 +92,7 @@ static std::vector<rmw_uds::RegistryQueryResult> query_all(
   auto * header = rmw_uds::registry_header(ctx->registry_ptr);
   // Lock-free: cleanup_stale + query both use the per-slot seqlock protocol
   // and may safely run concurrently with other readers/writers.
-  rmw_uds::registry_cleanup_stale(header);
+  maybe_cleanup_stale(ctx, header);
   return rmw_uds::registry_query(header, type, topic, node_name, node_ns);
 }
 

--- a/rmw_unix_socket_cpp/src/rmw_init.cpp
+++ b/rmw_unix_socket_cpp/src/rmw_init.cpp
@@ -14,6 +14,8 @@
 
 #include <sys/stat.h>
 
+#include <chrono>
+
 #include "identifier.hpp"
 #include "logging.hpp"
 #include "registry.hpp"
@@ -172,6 +174,15 @@ rmw_ret_t rmw_init(const rmw_init_options_t * options, rmw_context_t * context)
     rmw_uds::registry_cleanup_stale(init_header);
     rmw_uds::cleanup_orphan_socket_files(domain_id);
     rmw_uds::shm_cleanup_orphan_segments(domain_id);
+    // Date the sweep, or the first graph query — typically moments later,
+    // during node discovery — repeats the full stat-every-slot pass this one
+    // just paid for. Also keeps 0 unreachable as a live sentinel (steady_clock
+    // starts at boot, so a process starting within the first second of uptime
+    // would otherwise misread 0 as "swept just now").
+    ctx->last_cleanup_ns.store(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::steady_clock::now().time_since_epoch()).count(),
+      std::memory_order_relaxed);
   }
 
   rmw_uds::warn_if_sysctl_buffers_undersized();

--- a/rmw_unix_socket_cpp/src/types.hpp
+++ b/rmw_unix_socket_cpp/src/types.hpp
@@ -160,6 +160,11 @@ struct UdsContext
   std::atomic<bool> is_shutdown{false};
   std::atomic<uint64_t> last_registry_generation{0};
 
+  // Last time this process swept the registry for slots whose owning process
+  // is gone (steady clock, ns). Keeps that sweep off the graph query path; see
+  // maybe_cleanup_stale in rmw_graph.cpp.
+  std::atomic<int64_t> last_cleanup_ns{0};
+
   // Doorbell: a bound datagram socket other processes ring (one octet) after
   // any registry mutation, so a blocked rmw_wait re-checks the registry
   // without polling. Registered in the registry as ENTRY_DOORBELL; the slot's

--- a/rmw_unix_socket_cpp/src/types.hpp
+++ b/rmw_unix_socket_cpp/src/types.hpp
@@ -160,9 +160,10 @@ struct UdsContext
   std::atomic<bool> is_shutdown{false};
   std::atomic<uint64_t> last_registry_generation{0};
 
-  // Last time this process swept the registry for slots whose owning process
+  // Last time this context swept the registry for slots whose owning process
   // is gone (steady clock, ns). Keeps that sweep off the graph query path; see
-  // maybe_cleanup_stale in rmw_graph.cpp.
+  // maybe_cleanup_stale in rmw_graph.cpp. Stamped by the rmw_init sweep too;
+  // the registry-full fallback sweep in registry_add does not participate.
   std::atomic<int64_t> last_cleanup_ns{0};
 
   // Doorbell: a bound datagram socket other processes ring (one octet) after

--- a/rmw_unix_socket_cpp/test/test_base.hpp
+++ b/rmw_unix_socket_cpp/test/test_base.hpp
@@ -31,13 +31,15 @@ class RmwUdsTestBase : public ::testing::Test
 protected:
   rmw_context_t context = rmw_get_zero_initialized_context();
   rmw_init_options_t options = rmw_get_zero_initialized_init_options();
+  // Unique domain to avoid collisions with running ROS systems. A subclass
+  // constructor may override it for tests that need a private registry.
+  size_t domain_id = 99;
 
   void SetUp() override
   {
     rcutils_allocator_t allocator = rcutils_get_default_allocator();
     ASSERT_EQ(RMW_RET_OK, rmw_init_options_init(&options, allocator));
-    // Use a unique domain to avoid collisions with running ROS systems
-    options.domain_id = 99;
+    options.domain_id = domain_id;
     ASSERT_EQ(RMW_RET_OK, rmw_init(&options, &context));
   }
 

--- a/rmw_unix_socket_cpp/test/test_rmw_graph.cpp
+++ b/rmw_unix_socket_cpp/test/test_rmw_graph.cpp
@@ -14,6 +14,7 @@
 
 #include "test_base.hpp"
 
+#include <chrono>
 #include <cstring>
 #include <string>
 
@@ -51,7 +52,18 @@ TEST_F(RmwUdsNodeTest, GetNodeNames)
 
 // registry_cleanup_stale walks every live slot and stats /proc/<pid> for each
 // one. That is garbage collection, and it must not run on every graph query.
-TEST_F(RmwUdsNodeTest, GraphQueryThrottlesStaleCleanup)
+//
+// Private domain: the assertions below are negatives on shared registry state,
+// and domain 99 is one machine-global segment that every fixture-based test
+// binary sweeps unthrottled at rmw_init — under parallel ctest that reclaims
+// the ghost mid-test. (94-98 are taken by the other binaries, 99 by fixtures.)
+class RmwUdsGraphThrottleTest : public RmwUdsNodeTest
+{
+protected:
+  RmwUdsGraphThrottleTest() {domain_id = 93;}
+};
+
+TEST_F(RmwUdsGraphThrottleTest, GraphQueryThrottlesStaleCleanup)
 {
   auto * nd = static_cast<rmw_uds::UdsNode *>(node->data);
   auto * header = rmw_uds::registry_header(nd->context->registry_ptr);
@@ -82,18 +94,43 @@ TEST_F(RmwUdsNodeTest, GraphQueryThrottlesStaleCleanup)
       return found;
     };
 
-  // The first query after a quiet period does sweep, so this one is reclaimed.
-  ASSERT_GE(add_ghost("ghost_first"), 0);
+  auto steady_ns = [] {
+      return std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::steady_clock::now().time_since_epoch()).count();
+    };
+
+  // Age the stamp past the interval so the first query sweeps regardless of
+  // how recently rmw_init dated its own sweep.
+  nd->context->last_cleanup_ns.store(
+    steady_ns() - 2 * 1000000000LL, std::memory_order_relaxed);
+  const int32_t first = add_ghost("ghost_first");
+  ASSERT_GE(first, 0);
   EXPECT_FALSE(graph_lists("ghost_first")) <<
     "the first graph query should still reclaim dead slots";
 
-  // A second dead slot added immediately must survive: the sweep is throttled,
-  // so the very next query does not pay for another full stat() pass.
+  // Re-arm the throttle deterministically rather than racing the 1 s interval
+  // against the wall clock (a slow/sanitized run can lose that race).
+  nd->context->last_cleanup_ns.store(steady_ns(), std::memory_order_relaxed);
+
+  // A second dead slot added now must survive: the sweep is throttled, so the
+  // very next query does not pay for another full stat() pass.
   const int32_t second = add_ghost("ghost_second");
   ASSERT_GE(second, 0);
   EXPECT_TRUE(graph_lists("ghost_second")) <<
     "cleanup_stale ran again right away; the throttle is not in effect";
 
+  // And the sweep must resume once the interval has passed — "once per process
+  // lifetime" would satisfy the two assertions above. Age the stamp again
+  // instead of sleeping through the interval.
+  nd->context->last_cleanup_ns.store(
+    steady_ns() - 2 * 1000000000LL, std::memory_order_relaxed);
+  EXPECT_FALSE(graph_lists("ghost_second")) <<
+    "the sweep never resumed after the throttle interval passed";
+
+  // A failed assertion above strands a ghost in the persistent segment; remove
+  // unconditionally (no-op for slots the sweeps already reclaimed — nothing
+  // else writes this private domain, so the indices cannot have been reused).
+  rmw_uds::registry_remove(header, first);
   rmw_uds::registry_remove(header, second);
 }
 

--- a/rmw_unix_socket_cpp/test/test_rmw_graph.cpp
+++ b/rmw_unix_socket_cpp/test/test_rmw_graph.cpp
@@ -17,6 +17,9 @@
 #include <cstring>
 #include <string>
 
+#include "../src/registry.hpp"
+#include "../src/types.hpp"
+
 #include "test_msgs/msg/basic_types.hpp"
 
 #include "rmw/get_topic_names_and_types.h"
@@ -44,6 +47,54 @@ TEST_F(RmwUdsNodeTest, GetNodeNames)
 
   auto _r1 [[maybe_unused]] = rcutils_string_array_fini(&names);
   auto _r2 [[maybe_unused]] = rcutils_string_array_fini(&namespaces);
+}
+
+// registry_cleanup_stale walks every live slot and stats /proc/<pid> for each
+// one. That is garbage collection, and it must not run on every graph query.
+TEST_F(RmwUdsNodeTest, GraphQueryThrottlesStaleCleanup)
+{
+  auto * nd = static_cast<rmw_uds::UdsNode *>(node->data);
+  auto * header = rmw_uds::registry_header(nd->context->registry_ptr);
+
+  // A PID that cannot be running, so cleanup_stale sees the entry as dead.
+  constexpr pid_t DEAD_PID = 2147483000;
+  auto add_ghost = [&](const char * name) {
+      rmw_uds::RegistryEntry e;
+      std::memset(&e, 0, sizeof(e));
+      e.type = rmw_uds::ENTRY_NODE;
+      e.pid = DEAD_PID;
+      std::strncpy(e.node_name, name, sizeof(e.node_name) - 1);
+      return rmw_uds::registry_add(header, e);
+    };
+
+  auto graph_lists = [&](const char * name) {
+      rcutils_string_array_t names = rcutils_get_zero_initialized_string_array();
+      rcutils_string_array_t namespaces = rcutils_get_zero_initialized_string_array();
+      EXPECT_EQ(RMW_RET_OK, rmw_get_node_names(node, &names, &namespaces));
+      bool found = false;
+      for (size_t i = 0; i < names.size; ++i) {
+        if (std::string(names.data[i]) == name) {
+          found = true;
+        }
+      }
+      auto _r1 [[maybe_unused]] = rcutils_string_array_fini(&names);
+      auto _r2 [[maybe_unused]] = rcutils_string_array_fini(&namespaces);
+      return found;
+    };
+
+  // The first query after a quiet period does sweep, so this one is reclaimed.
+  ASSERT_GE(add_ghost("ghost_first"), 0);
+  EXPECT_FALSE(graph_lists("ghost_first")) <<
+    "the first graph query should still reclaim dead slots";
+
+  // A second dead slot added immediately must survive: the sweep is throttled,
+  // so the very next query does not pay for another full stat() pass.
+  const int32_t second = add_ghost("ghost_second");
+  ASSERT_GE(second, 0);
+  EXPECT_TRUE(graph_lists("ghost_second")) <<
+    "cleanup_stale ran again right away; the throttle is not in effect";
+
+  rmw_uds::registry_remove(header, second);
 }
 
 TEST_F(RmwUdsNodeTest, CountPublishersAndSubscribers)


### PR DESCRIPTION
query_all ran registry_cleanup_stale before every graph query, and it has 13 call sites, so rmw_get_node_names, rmw_count_publishers, rmw_count_subscribers, rmw_get_topic_names_and_types and the rest all paid for it. The sweep walks every live slot, copies 1164 bytes out of each and stats /proc/<pid> to decide whether the owner is still alive.

Measured on one registry:

    live entries    one sweep    via rmw_get_topic_names_and_types
    1335            1.4 ms       2.9 ms
    9235            21.3 ms      42.6 ms
    12671           27.2 ms      54.4 ms

rmw_get_topic_names_and_types calls query_all twice, so it paid twice. Anything polling the graph paid it several times a second whether or not the graph had changed.

Reclaiming slots owned by dead processes is garbage collection and does not belong on a read path. Sweep at most once per second per context instead, guarded by a CAS so concurrent callers skip rather than queue up behind each other.

No guarantee is weakened. A graph query could already return an entity whose owner died just after the sweep that vetted it, so the result was never a liveness statement; this only widens a window that was always open. The full-registry path in registry_add still sweeps unconditionally, since there it is the last resort before entity creation fails.

test_rmw_graph now compiles registry.cpp so it can seed the registry directly.

Closes #52