### PR TITLE
ci: add CodeQL analysis over the real colcon build

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,86 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main, devel]
+  pull_request:
+    branches: [main, devel]
+  schedule:
+    # Weekly, so a query-pack update finds existing code without waiting for
+    # the next push.
+    - cron: '31 4 * * 1'
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: analyze (c-cpp)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write   # upload the SARIF results
+      contents: read
+      actions: read
+    container:
+      # Same base as CI: CodeQL has to observe the real compiler invocations,
+      # which means the real ROS headers and the real find_package results.
+      image: ros:jazzy-ros-base
+      options: --shm-size=1g
+
+    steps:
+      - name: Install build prerequisites
+        shell: bash
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            git \
+            python3-colcon-common-extensions \
+            python3-rosdep
+
+      - uses: actions/checkout@v4
+
+      - name: Resolve package dependencies
+        shell: bash
+        run: |
+          rosdep update --rosdistro=jazzy
+          # Mirrors the CI workflow: rosdep's --from-paths defaults exclude
+          # test deps, and BUILD_TESTING=ON (colcon build default) fails to
+          # configure without them. The tests are part of what gets analyzed.
+          rosdep install --from-paths rmw_unix_socket_cpp --ignore-src -r -y \
+            --rosdistro=jazzy \
+            --dependency-types=buildtool \
+            --dependency-types=build \
+            --dependency-types=build_export \
+            --dependency-types=exec \
+            --dependency-types=test
+          apt-get install -y --no-install-recommends \
+            ros-jazzy-test-msgs \
+            ros-jazzy-rosidl-typesupport-cpp \
+            ros-jazzy-rosidl-runtime-cpp
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: c-cpp
+          # Manual, not autobuild. Autobuild guesses at the build system and
+          # would run cmake without the ROS environment sourced, so
+          # find_package(rmw) fails and CodeQL ends up analyzing nothing.
+          build-mode: manual
+          # Superset of security-extended: adds the correctness and
+          # maintainability queries. security-extended alone is the leaner
+          # choice if the quality results turn out to be noise.
+          queries: security-and-quality
+
+      - name: Build
+        shell: bash
+        run: |
+          source /opt/ros/jazzy/setup.bash
+          # Debug rather than Release: -O2 inlines and folds enough that some
+          # dataflow paths stop being visible to the extractor.
+          colcon build \
+            --paths rmw_unix_socket_cpp \
+            --event-handlers console_direct+ \
+            --cmake-args -DCMAKE_BUILD_TYPE=Debug
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:c-cpp"


### PR DESCRIPTION
## Description

Adds CodeQL analysis over the real `colcon` build. Free on public repositories,
native to GitHub, and one workflow file with no ongoing upkeep.

What it adds over build-and-test is the interprocedural class of bug: use-after-free,
buffer overflow, null dereference on a path no test happens to take. For a codebase
that hands raw endpoint pointers between an epoll dispatch and whatever thread is
tearing an endpoint down, and `memcpy`s fixed-size buffers out of shared memory,
that is the half worth having.

**This is the advanced setup (a committed workflow), not the one-click default
setup**, and the reason matters. Default setup runs `autobuild`. Autobuild guesses
at the build system and would invoke `cmake` without the ROS environment sourced,
so `find_package(rmw)` fails, nothing compiles, and CodeQL uploads an **empty
database** — a green check that means nothing. `build-mode: manual` puts the
tracer around the same `colcon build --paths rmw_unix_socket_cpp` that CI runs, in
the same `ros:jazzy-ros-base` container, so the extractor observes the real
compiler invocations with the real headers.

<!-- No linked issue for this change; add `Fixes #<n>` here if one applies. -->

### Is this user-facing behavior change?

No. CI configuration only; no source, build or packaging change.

### How was this tested?

The workflow triggers on `pull_request` against `devel`, so **this PR is its own
test** — the `analyze (c-cpp)` check on this PR is a real run of the thing being
added. Worth confirming two specific things in that run before merging:

1. **The build step compiled something.** If `find_package` had failed, CodeQL
   would still report success over an empty database. The build log should show
   the package's translation units compiling.
2. **CodeQL init works inside the container.** The action is documented as
   container-compatible, but that is the part I could not verify locally.

Locally I verified only that the YAML parses and that the build command it runs is
the one that works. Everything else is what the first CI run is for.

### Did you use Generative AI?

### Additional Information

Two deliberate differences from `ci.yml`:

- **`Debug` instead of `Release`.** At `-O2` the inlining and constant folding
  remove enough structure that some dataflow paths stop being visible to the
  extractor.
- **One distro, not the four-distro matrix.** The analysis is over our sources,
  which do not differ per distro; the matrix exists to catch per-distro API drift,
  which is a build problem rather than an analysis one.

Query pack is `security-and-quality`, the superset that adds correctness and
maintainability queries on top of `security-extended`. If the quality half proves
noisy, dropping to `security-extended` is a one-line change.

Also runs weekly on a schedule so a query-pack update is applied to existing code
rather than waiting for the next push to touch it.

Independent of the other open PRs — touches only `.github/workflows/`.
